### PR TITLE
fix: add missing configuration accessors for api keys

### DIFF
--- a/lib/onesignal/configuration.rb
+++ b/lib/onesignal/configuration.rb
@@ -39,6 +39,12 @@ module OneSignal
     # OneSignal API token for User Authentication
     attr_accessor :user_key
 
+    # OneSignal Organization API Key
+    attr_accessor :organization_api_key
+
+    # OneSignal REST API Key
+    attr_accessor :rest_api_key
+
     # Set this to enable/disable debugging. When enabled (set to true), HTTP request/response
     # details will be logged with `logger.debug` (see the `logger` attribute).
     # Default to false.

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -39,4 +39,16 @@ describe OneSignal::Configuration do
       end
     end
   end
+
+  describe 'API keys' do
+    it 'should allow setting and retrieving organization_api_key' do
+      config.organization_api_key = 'test_org_key'
+      expect(config.organization_api_key).to eq('test_org_key')
+    end
+
+    it 'should allow setting and retrieving rest_api_key' do
+      config.rest_api_key = 'test_rest_key'
+      expect(config.rest_api_key).to eq('test_rest_key')
+    end
+  end
 end


### PR DESCRIPTION
# Description
## fix: add missing configuration accessors for api keys

## Details
### Motivation
Fixes NoMethodError when configuring organization_api_key and rest_api_key. These keys are required for authentication but were missing from the Configuration class.

### Scope
- Add attr_accessor for organization_api_key and rest_api_key in configuration.rb
- Add specs to verify these keys can be configured

# Testing
## Manual testing
- add specs for new attr
- include gem in local repo and add config 

# Checklist
## Overview
   - [ x ] I have filled out all **REQUIRED** sections above
   - [ x ] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [ x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.