### PR TITLE
Add v5.4.0 package updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,11 +57,6 @@ jobs:
           ruby-version: '3.2'
           bundler-cache: true
 
-      - name: Build gem
-        run: |
-          gem build onesignal.gemspec
-          ls -la *.gem
-
       - name: Publish to RubyGems
         uses: rubygems/release-gem@v1
         env:


### PR DESCRIPTION
## Release v5.4.0

### 🚀 Features
- feat(ci): close stale user-api-updates PRs before fan-out

### 🐛 Bug Fixes
- fix(ruby): remove redundant gem build step from release workflow
- fix(ci): tolerate gh pr close failures during stale PR cleanup

### 🔧 Internal
- build(release): bump package versions
- test(ruby): use string outer / symbol inner keys for result.content
- build(ruby): sync release workflow fix
- ci: generate real release notes in downstream PR bodies
- ci: correct release-notes anchor + warn on compareCommits truncation

---
_Generated from [OneSignal/api-client-libraries@bc71af6...9e7b64a](https://github.com/OneSignal/api-client-libraries/compare/bc71af602529f22c0d442e3b60e585fb0ad14264...9e7b64afe8e277a5c2f8444e8bf158e759278e53)._