### PR TITLE
Add v5.4.0 package updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,11 +57,6 @@ jobs:
           ruby-version: '3.2'
           bundler-cache: true
 
-      - name: Build gem
-        run: |
-          gem build onesignal.gemspec
-          ls -la *.gem
-
       - name: Publish to RubyGems
         uses: rubygems/release-gem@v1
         env:


### PR DESCRIPTION
## Release v5.4.0

### 🚀 Features
- feat(ci): close stale user-api-updates PRs before fan-out

### 🐛 Bug Fixes
- fix(ruby): remove redundant gem build step from release workflow
- fix(ci): tolerate gh pr close failures during stale PR cleanup

### 🔧 Internal
- build(release): bump package versions
- test(ruby): use string outer / symbol inner keys for result.content
- build(ruby): sync release workflow fix
- ci: generate real release notes in downstream PR bodies
- ci: correct release-notes anchor + warn on compareCommits truncation
- ci: add script/bump-version helper
- ci: auto-populate root release PR body via sdk-shared/create-release.yml
- ci: add one-click release orchestrator via sdk-shared/prep-release.yml
- ci: unstage devdist's pre-staged outputs deletions before chore commit
- ci: delegate release version math to node-semver CLI

---
_Generated from [OneSignal/api-client-libraries@bc71af6...a744748](https://github.com/OneSignal/api-client-libraries/compare/bc71af602529f22c0d442e3b60e585fb0ad14264...a7447480f0bc930ca3611053f8cec6fc0a5f778d)._