### PR TITLE
docs: add v5.4.0 package updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,11 +57,6 @@ jobs:
           ruby-version: '3.2'
           bundler-cache: true
 
-      - name: Build gem
-        run: |
-          gem build onesignal.gemspec
-          ls -la *.gem
-
       - name: Publish to RubyGems
         uses: rubygems/release-gem@v1
         env:

--- a/docs/DefaultApi.md
+++ b/docs/DefaultApi.md
@@ -573,7 +573,11 @@ OneSignal.configure do |config|
 end
 
 api_instance = OneSignal::DefaultApi.new
-notification = OneSignal::Notification.new({app_id: 'app_id_example'}) # Notification | 
+notification = OneSignal::Notification.new
+notification.app_id = 'YOUR_APP_ID'
+notification.contents = OneSignal::LanguageStringMap.new({ en: 'Hello from OneSignal!' })
+notification.include_aliases = { 'external_id' => ['YOUR_USER_EXTERNAL_ID'] }
+notification.target_channel = 'push'
 
 begin
   # Create notification


### PR DESCRIPTION
## Updates
- docs: add flat create-notification doc examples via vendor extension
- ci: remove redundant gem build step from release workflow

---
_Generated from [OneSignal/api-client-libraries@bc71af6...35a92b9](https://github.com/OneSignal/api-client-libraries/compare/bc71af602529f22c0d442e3b60e585fb0ad14264...35a92b9872393d79d8270897b2e134f2b42562b0)._