### PR TITLE
feat: add v5.4.0 package updates

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -14,4 +14,4 @@ jobs:
         with:
           # SDK Server Project
           project-url: https://github.com/orgs/OneSignal/projects/11
-          github-token: ${{ secrets.GH_PROJECTS_TOKEN }}
+          github-token: ${{ secrets.GH_PUSH_TOKEN }}

--- a/docs/BasicNotification.md
+++ b/docs/BasicNotification.md
@@ -109,6 +109,7 @@
 | **email_preheader** | **String** | Channel: Email The preheader text of the email. Preheader is the preview text displayed immediately after an email subject that provides additional context about the email content. If not specified, will default to null.  | [optional] |
 | **disable_email_click_tracking** | **Boolean** | Channel: Email Default is &#x60;false&#x60;. If set to &#x60;true&#x60;, the URLs sent within the email will not include link tracking and will be the same as originally set; otherwise, all the URLs in the email will be tracked. | [optional] |
 | **include_unsubscribed** | **Boolean** | Channel: Email Default is &#x60;false&#x60;. This field is used to send transactional notifications. If set to &#x60;true&#x60;, this notification will also be sent to unsubscribed emails. If a &#x60;template_id&#x60; is provided, the &#x60;include_unsubscribed&#x60; value from the template will be inherited. If you are using a third-party ESP, this field requires the ESP&#39;s list of unsubscribed emails to be cleared. | [optional] |
+| **email_bcc** | **Array&lt;String&gt;** | Channel: Email BCC recipients for the email. Maximum 5 addresses. Only supported when the email service provider is OneSignal Email.  | [optional] |
 | **sms_from** | **String** | Channel: SMS Phone Number used to send SMS. Should be a registered Twilio phone number in E.164 format.  | [optional] |
 | **sms_media_urls** | **Array&lt;String&gt;** | Channel: SMS URLs for the media files to be attached to the SMS content. Limit: 10 media urls with a total max. size of 5MBs.  | [optional] |
 | **filters** | [**Array&lt;FilterExpression&gt;**](FilterExpression.md) |  | [optional] |
@@ -230,6 +231,7 @@ instance = OneSignal::BasicNotification.new(
   email_preheader: null,
   disable_email_click_tracking: null,
   include_unsubscribed: null,
+  email_bcc: null,
   sms_from: null,
   sms_media_urls: null,
   filters: null,

--- a/docs/BasicNotificationAllOf.md
+++ b/docs/BasicNotificationAllOf.md
@@ -96,6 +96,7 @@
 | **email_preheader** | **String** | Channel: Email The preheader text of the email. Preheader is the preview text displayed immediately after an email subject that provides additional context about the email content. If not specified, will default to null.  | [optional] |
 | **disable_email_click_tracking** | **Boolean** | Channel: Email Default is &#x60;false&#x60;. If set to &#x60;true&#x60;, the URLs sent within the email will not include link tracking and will be the same as originally set; otherwise, all the URLs in the email will be tracked. | [optional] |
 | **include_unsubscribed** | **Boolean** | Channel: Email Default is &#x60;false&#x60;. This field is used to send transactional notifications. If set to &#x60;true&#x60;, this notification will also be sent to unsubscribed emails. If a &#x60;template_id&#x60; is provided, the &#x60;include_unsubscribed&#x60; value from the template will be inherited. If you are using a third-party ESP, this field requires the ESP&#39;s list of unsubscribed emails to be cleared. | [optional] |
+| **email_bcc** | **Array&lt;String&gt;** | Channel: Email BCC recipients for the email. Maximum 5 addresses. Only supported when the email service provider is OneSignal Email.  | [optional] |
 | **sms_from** | **String** | Channel: SMS Phone Number used to send SMS. Should be a registered Twilio phone number in E.164 format.  | [optional] |
 | **sms_media_urls** | **Array&lt;String&gt;** | Channel: SMS URLs for the media files to be attached to the SMS content. Limit: 10 media urls with a total max. size of 5MBs.  | [optional] |
 | **filters** | [**Array&lt;FilterExpression&gt;**](FilterExpression.md) |  | [optional] |
@@ -204,6 +205,7 @@ instance = OneSignal::BasicNotificationAllOf.new(
   email_preheader: null,
   disable_email_click_tracking: null,
   include_unsubscribed: null,
+  email_bcc: null,
   sms_from: null,
   sms_media_urls: null,
   filters: null,

--- a/docs/CreateTemplateRequest.md
+++ b/docs/CreateTemplateRequest.md
@@ -12,6 +12,7 @@
 | **is_email** | **Boolean** | Set true for an Email template. | [optional] |
 | **email_subject** | **String** | Subject of the email. | [optional] |
 | **email_body** | **String** | Body of the email (HTML supported). | [optional] |
+| **email_bcc** | **Array&lt;String&gt;** | BCC recipients for the email template. Maximum 5 addresses. Only supported when the email service provider is OneSignal Email. | [optional] |
 | **is_sms** | **Boolean** | Set true for an SMS template. | [optional] |
 | **dynamic_content** | **String** | JSON string for dynamic content personalization. | [optional] |
 
@@ -29,6 +30,7 @@ instance = OneSignal::CreateTemplateRequest.new(
   is_email: null,
   email_subject: null,
   email_body: null,
+  email_bcc: null,
   is_sms: null,
   dynamic_content: null
 )

--- a/docs/Notification.md
+++ b/docs/Notification.md
@@ -109,6 +109,7 @@
 | **email_preheader** | **String** | Channel: Email The preheader text of the email. Preheader is the preview text displayed immediately after an email subject that provides additional context about the email content. If not specified, will default to null.  | [optional] |
 | **disable_email_click_tracking** | **Boolean** | Channel: Email Default is &#x60;false&#x60;. If set to &#x60;true&#x60;, the URLs sent within the email will not include link tracking and will be the same as originally set; otherwise, all the URLs in the email will be tracked. | [optional] |
 | **include_unsubscribed** | **Boolean** | Channel: Email Default is &#x60;false&#x60;. This field is used to send transactional notifications. If set to &#x60;true&#x60;, this notification will also be sent to unsubscribed emails. If a &#x60;template_id&#x60; is provided, the &#x60;include_unsubscribed&#x60; value from the template will be inherited. If you are using a third-party ESP, this field requires the ESP&#39;s list of unsubscribed emails to be cleared. | [optional] |
+| **email_bcc** | **Array&lt;String&gt;** | Channel: Email BCC recipients for the email. Maximum 5 addresses. Only supported when the email service provider is OneSignal Email.  | [optional] |
 | **sms_from** | **String** | Channel: SMS Phone Number used to send SMS. Should be a registered Twilio phone number in E.164 format.  | [optional] |
 | **sms_media_urls** | **Array&lt;String&gt;** | Channel: SMS URLs for the media files to be attached to the SMS content. Limit: 10 media urls with a total max. size of 5MBs.  | [optional] |
 | **filters** | [**Array&lt;FilterExpression&gt;**](FilterExpression.md) |  | [optional] |
@@ -231,6 +232,7 @@ instance = OneSignal::Notification.new(
   email_preheader: null,
   disable_email_click_tracking: null,
   include_unsubscribed: null,
+  email_bcc: null,
   sms_from: null,
   sms_media_urls: null,
   filters: null,

--- a/docs/NotificationWithMeta.md
+++ b/docs/NotificationWithMeta.md
@@ -109,6 +109,7 @@
 | **email_preheader** | **String** | Channel: Email The preheader text of the email. Preheader is the preview text displayed immediately after an email subject that provides additional context about the email content. If not specified, will default to null.  | [optional] |
 | **disable_email_click_tracking** | **Boolean** | Channel: Email Default is &#x60;false&#x60;. If set to &#x60;true&#x60;, the URLs sent within the email will not include link tracking and will be the same as originally set; otherwise, all the URLs in the email will be tracked. | [optional] |
 | **include_unsubscribed** | **Boolean** | Channel: Email Default is &#x60;false&#x60;. This field is used to send transactional notifications. If set to &#x60;true&#x60;, this notification will also be sent to unsubscribed emails. If a &#x60;template_id&#x60; is provided, the &#x60;include_unsubscribed&#x60; value from the template will be inherited. If you are using a third-party ESP, this field requires the ESP&#39;s list of unsubscribed emails to be cleared. | [optional] |
+| **email_bcc** | **Array&lt;String&gt;** | BCC recipients that were set on this email notification. | [optional] |
 | **sms_from** | **String** | Channel: SMS Phone Number used to send SMS. Should be a registered Twilio phone number in E.164 format.  | [optional] |
 | **sms_media_urls** | **Array&lt;String&gt;** | Channel: SMS URLs for the media files to be attached to the SMS content. Limit: 10 media urls with a total max. size of 5MBs.  | [optional] |
 | **filters** | [**Array&lt;FilterExpression&gt;**](FilterExpression.md) |  | [optional] |
@@ -130,6 +131,7 @@
 | **completed_at** | **Integer** | Unix timestamp indicating when notification delivery completed. The delivery duration from start to finish can be calculated with completed_at - send_after. | [optional] |
 | **platform_delivery_stats** | [**PlatformDeliveryData**](PlatformDeliveryData.md) |  | [optional] |
 | **canceled** | **Boolean** | Indicates whether the notification was canceled before it could be sent. | [optional] |
+| **bcc_sent** | **Integer** | Number of BCC copies successfully sent for this notification. | [optional] |
 
 ## Example
 
@@ -242,6 +244,7 @@ instance = OneSignal::NotificationWithMeta.new(
   email_preheader: null,
   disable_email_click_tracking: null,
   include_unsubscribed: null,
+  email_bcc: null,
   sms_from: null,
   sms_media_urls: null,
   filters: null,
@@ -262,7 +265,8 @@ instance = OneSignal::NotificationWithMeta.new(
   send_after: null,
   completed_at: null,
   platform_delivery_stats: null,
-  canceled: null
+  canceled: null,
+  bcc_sent: null
 )
 ```
 

--- a/docs/NotificationWithMetaAllOf.md
+++ b/docs/NotificationWithMetaAllOf.md
@@ -16,6 +16,8 @@
 | **received** | **Integer** | Confirmed Deliveries number of devices that received the push notification. Paid Feature Only. Free accounts will see 0. | [optional] |
 | **throttle_rate_per_minute** | **Integer** | number of push notifications sent per minute. Paid Feature Only. If throttling is not enabled for the app or the notification, and for free accounts, null is returned. Refer to Throttling for more details. | [optional] |
 | **canceled** | **Boolean** | Indicates whether the notification was canceled before it could be sent. | [optional] |
+| **email_bcc** | **Array&lt;String&gt;** | BCC recipients that were set on this email notification. | [optional] |
+| **bcc_sent** | **Integer** | Number of BCC copies successfully sent for this notification. | [optional] |
 
 ## Example
 
@@ -34,7 +36,9 @@ instance = OneSignal::NotificationWithMetaAllOf.new(
   platform_delivery_stats: null,
   received: null,
   throttle_rate_per_minute: null,
-  canceled: null
+  canceled: null,
+  email_bcc: null,
+  bcc_sent: null
 )
 ```
 

--- a/docs/UpdateTemplateRequest.md
+++ b/docs/UpdateTemplateRequest.md
@@ -11,6 +11,7 @@
 | **is_email** | **Boolean** | Set true for an Email template. | [optional] |
 | **email_subject** | **String** | Subject of the email. | [optional] |
 | **email_body** | **String** | Body of the email (HTML supported). | [optional] |
+| **email_bcc** | **Array&lt;String&gt;** | BCC recipients for the email template. Maximum 5 addresses. Only supported when the email service provider is OneSignal Email. | [optional] |
 | **is_sms** | **Boolean** | Set true for an SMS template. | [optional] |
 | **dynamic_content** | **String** | JSON string for dynamic content personalization. | [optional] |
 
@@ -27,6 +28,7 @@ instance = OneSignal::UpdateTemplateRequest.new(
   is_email: null,
   email_subject: null,
   email_body: null,
+  email_bcc: null,
   is_sms: null,
   dynamic_content: null
 )

--- a/lib/onesignal/models/basic_notification.rb
+++ b/lib/onesignal/models/basic_notification.rb
@@ -322,6 +322,9 @@ module OneSignal
     # Channel: Email Default is `false`. This field is used to send transactional notifications. If set to `true`, this notification will also be sent to unsubscribed emails. If a `template_id` is provided, the `include_unsubscribed` value from the template will be inherited. If you are using a third-party ESP, this field requires the ESP's list of unsubscribed emails to be cleared.
     attr_accessor :include_unsubscribed
 
+    # Channel: Email BCC recipients for the email. Maximum 5 addresses. Only supported when the email service provider is OneSignal Email. 
+    attr_accessor :email_bcc
+
     # Channel: SMS Phone Number used to send SMS. Should be a registered Twilio phone number in E.164 format. 
     attr_accessor :sms_from
 
@@ -478,6 +481,7 @@ module OneSignal
         :'email_preheader' => :'email_preheader',
         :'disable_email_click_tracking' => :'disable_email_click_tracking',
         :'include_unsubscribed' => :'include_unsubscribed',
+        :'email_bcc' => :'email_bcc',
         :'sms_from' => :'sms_from',
         :'sms_media_urls' => :'sms_media_urls',
         :'filters' => :'filters',
@@ -603,6 +607,7 @@ module OneSignal
         :'email_preheader' => :'String',
         :'disable_email_click_tracking' => :'Boolean',
         :'include_unsubscribed' => :'Boolean',
+        :'email_bcc' => :'Array<String>',
         :'sms_from' => :'String',
         :'sms_media_urls' => :'Array<String>',
         :'filters' => :'Array<FilterExpression>',
@@ -700,6 +705,7 @@ module OneSignal
         :'email_reply_to_address',
         :'email_preheader',
         :'disable_email_click_tracking',
+        :'email_bcc',
         :'sms_from',
         :'sms_media_urls',
         :'filters',
@@ -1183,6 +1189,12 @@ module OneSignal
         self.include_unsubscribed = attributes[:'include_unsubscribed']
       end
 
+      if attributes.key?(:'email_bcc')
+        if (value = attributes[:'email_bcc']).is_a?(Array)
+          self.email_bcc = value
+        end
+      end
+
       if attributes.key?(:'sms_from')
         self.sms_from = attributes[:'sms_from']
       end
@@ -1232,6 +1244,10 @@ module OneSignal
         invalid_properties.push('invalid value for "app_id", app_id cannot be nil.')
       end
 
+      if !@email_bcc.nil? && @email_bcc.length > 5
+        invalid_properties.push('invalid value for "email_bcc", number of items must be less than or equal to 5.')
+      end
+
       invalid_properties
     end
 
@@ -1243,6 +1259,7 @@ module OneSignal
       aggregation_validator = EnumAttributeValidator.new('String', ["sum", "count"])
       return false unless aggregation_validator.valid?(@aggregation)
       return false if @app_id.nil?
+      return false if !@email_bcc.nil? && @email_bcc.length > 5
       huawei_category_validator = EnumAttributeValidator.new('String', ["IM", "VOIP", "SUBSCRIPTION", "TRAVEL", "HEALTH", "WORK", "ACCOUNT", "EXPRESS", "FINANCE", "DEVICE_REMINDER", "MAIL", "MARKETING"])
       return false unless huawei_category_validator.valid?(@huawei_category)
       true
@@ -1266,6 +1283,16 @@ module OneSignal
         fail ArgumentError, "invalid value for \"aggregation\", must be one of #{validator.allowable_values}."
       end
       @aggregation = aggregation
+    end
+
+    # Custom attribute writer method with validation
+    # @param [Object] email_bcc Value to be assigned
+    def email_bcc=(email_bcc)
+      if !email_bcc.nil? && email_bcc.length > 5
+        fail ArgumentError, 'invalid value for "email_bcc", number of items must be less than or equal to 5.'
+      end
+
+      @email_bcc = email_bcc
     end
 
     # Custom attribute writer method checking allowed values (enum).
@@ -1388,6 +1415,7 @@ module OneSignal
           email_preheader == o.email_preheader &&
           disable_email_click_tracking == o.disable_email_click_tracking &&
           include_unsubscribed == o.include_unsubscribed &&
+          email_bcc == o.email_bcc &&
           sms_from == o.sms_from &&
           sms_media_urls == o.sms_media_urls &&
           filters == o.filters &&
@@ -1408,7 +1436,7 @@ module OneSignal
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [included_segments, excluded_segments, include_subscription_ids, include_email_tokens, include_phone_numbers, include_ios_tokens, include_wp_wns_uris, include_amazon_reg_ids, include_chrome_reg_ids, include_chrome_web_reg_ids, include_android_reg_ids, include_aliases, target_channel, id, value, name, aggregation, is_ios, is_android, is_huawei, is_any_web, is_chrome_web, is_firefox, is_safari, is_wp_wns, is_adm, is_chrome, app_id, external_id, idempotency_key, contents, headings, subtitle, data, huawei_msg_type, url, web_url, app_url, ios_attachments, template_id, content_available, mutable_content, target_content_identifier, big_picture, huawei_big_picture, adm_big_picture, chrome_big_picture, chrome_web_image, buttons, web_buttons, ios_category, android_channel_id, huawei_channel_id, existing_android_channel_id, huawei_existing_channel_id, android_background_layout, small_icon, huawei_small_icon, large_icon, huawei_large_icon, adm_small_icon, adm_large_icon, chrome_web_icon, chrome_web_badge, firefox_icon, chrome_icon, ios_sound, android_sound, huawei_sound, adm_sound, wp_wns_sound, android_led_color, huawei_led_color, android_accent_color, huawei_accent_color, android_visibility, huawei_visibility, ios_badge_type, ios_badge_count, collapse_id, web_push_topic, apns_alert, delayed_option, delivery_time_of_day, ttl, priority, apns_push_type_override, throttle_rate_per_minute, android_group, android_group_message, adm_group, adm_group_message, thread_id, summary_arg, summary_arg_count, ios_relevance_score, ios_interruption_level, email_subject, email_body, email_from_name, email_from_address, email_reply_to_address, email_preheader, disable_email_click_tracking, include_unsubscribed, sms_from, sms_media_urls, filters, custom_data, huawei_badge_class, huawei_badge_add_num, huawei_badge_set_num, huawei_category, huawei_bi_tag].hash
+      [included_segments, excluded_segments, include_subscription_ids, include_email_tokens, include_phone_numbers, include_ios_tokens, include_wp_wns_uris, include_amazon_reg_ids, include_chrome_reg_ids, include_chrome_web_reg_ids, include_android_reg_ids, include_aliases, target_channel, id, value, name, aggregation, is_ios, is_android, is_huawei, is_any_web, is_chrome_web, is_firefox, is_safari, is_wp_wns, is_adm, is_chrome, app_id, external_id, idempotency_key, contents, headings, subtitle, data, huawei_msg_type, url, web_url, app_url, ios_attachments, template_id, content_available, mutable_content, target_content_identifier, big_picture, huawei_big_picture, adm_big_picture, chrome_big_picture, chrome_web_image, buttons, web_buttons, ios_category, android_channel_id, huawei_channel_id, existing_android_channel_id, huawei_existing_channel_id, android_background_layout, small_icon, huawei_small_icon, large_icon, huawei_large_icon, adm_small_icon, adm_large_icon, chrome_web_icon, chrome_web_badge, firefox_icon, chrome_icon, ios_sound, android_sound, huawei_sound, adm_sound, wp_wns_sound, android_led_color, huawei_led_color, android_accent_color, huawei_accent_color, android_visibility, huawei_visibility, ios_badge_type, ios_badge_count, collapse_id, web_push_topic, apns_alert, delayed_option, delivery_time_of_day, ttl, priority, apns_push_type_override, throttle_rate_per_minute, android_group, android_group_message, adm_group, adm_group_message, thread_id, summary_arg, summary_arg_count, ios_relevance_score, ios_interruption_level, email_subject, email_body, email_from_name, email_from_address, email_reply_to_address, email_preheader, disable_email_click_tracking, include_unsubscribed, email_bcc, sms_from, sms_media_urls, filters, custom_data, huawei_badge_class, huawei_badge_add_num, huawei_badge_set_num, huawei_category, huawei_bi_tag].hash
     end
 
     # Builds the object from hash

--- a/lib/onesignal/models/basic_notification_all_of.rb
+++ b/lib/onesignal/models/basic_notification_all_of.rb
@@ -284,6 +284,9 @@ module OneSignal
     # Channel: Email Default is `false`. This field is used to send transactional notifications. If set to `true`, this notification will also be sent to unsubscribed emails. If a `template_id` is provided, the `include_unsubscribed` value from the template will be inherited. If you are using a third-party ESP, this field requires the ESP's list of unsubscribed emails to be cleared.
     attr_accessor :include_unsubscribed
 
+    # Channel: Email BCC recipients for the email. Maximum 5 addresses. Only supported when the email service provider is OneSignal Email. 
+    attr_accessor :email_bcc
+
     # Channel: SMS Phone Number used to send SMS. Should be a registered Twilio phone number in E.164 format. 
     attr_accessor :sms_from
 
@@ -427,6 +430,7 @@ module OneSignal
         :'email_preheader' => :'email_preheader',
         :'disable_email_click_tracking' => :'disable_email_click_tracking',
         :'include_unsubscribed' => :'include_unsubscribed',
+        :'email_bcc' => :'email_bcc',
         :'sms_from' => :'sms_from',
         :'sms_media_urls' => :'sms_media_urls',
         :'filters' => :'filters',
@@ -539,6 +543,7 @@ module OneSignal
         :'email_preheader' => :'String',
         :'disable_email_click_tracking' => :'Boolean',
         :'include_unsubscribed' => :'Boolean',
+        :'email_bcc' => :'Array<String>',
         :'sms_from' => :'String',
         :'sms_media_urls' => :'Array<String>',
         :'filters' => :'Array<FilterExpression>',
@@ -634,6 +639,7 @@ module OneSignal
         :'email_reply_to_address',
         :'email_preheader',
         :'disable_email_click_tracking',
+        :'email_bcc',
         :'sms_from',
         :'sms_media_urls',
         :'filters',
@@ -1033,6 +1039,12 @@ module OneSignal
         self.include_unsubscribed = attributes[:'include_unsubscribed']
       end
 
+      if attributes.key?(:'email_bcc')
+        if (value = attributes[:'email_bcc']).is_a?(Array)
+          self.email_bcc = value
+        end
+      end
+
       if attributes.key?(:'sms_from')
         self.sms_from = attributes[:'sms_from']
       end
@@ -1078,6 +1090,10 @@ module OneSignal
     # @return Array for valid properties with the reasons
     def list_invalid_properties
       invalid_properties = Array.new
+      if !@email_bcc.nil? && @email_bcc.length > 5
+        invalid_properties.push('invalid value for "email_bcc", number of items must be less than or equal to 5.')
+      end
+
       invalid_properties
     end
 
@@ -1086,6 +1102,7 @@ module OneSignal
     def valid?
       aggregation_validator = EnumAttributeValidator.new('String', ["sum", "count"])
       return false unless aggregation_validator.valid?(@aggregation)
+      return false if !@email_bcc.nil? && @email_bcc.length > 5
       huawei_category_validator = EnumAttributeValidator.new('String', ["IM", "VOIP", "SUBSCRIPTION", "TRAVEL", "HEALTH", "WORK", "ACCOUNT", "EXPRESS", "FINANCE", "DEVICE_REMINDER", "MAIL", "MARKETING"])
       return false unless huawei_category_validator.valid?(@huawei_category)
       true
@@ -1099,6 +1116,16 @@ module OneSignal
         fail ArgumentError, "invalid value for \"aggregation\", must be one of #{validator.allowable_values}."
       end
       @aggregation = aggregation
+    end
+
+    # Custom attribute writer method with validation
+    # @param [Object] email_bcc Value to be assigned
+    def email_bcc=(email_bcc)
+      if !email_bcc.nil? && email_bcc.length > 5
+        fail ArgumentError, 'invalid value for "email_bcc", number of items must be less than or equal to 5.'
+      end
+
+      @email_bcc = email_bcc
     end
 
     # Custom attribute writer method checking allowed values (enum).
@@ -1208,6 +1235,7 @@ module OneSignal
           email_preheader == o.email_preheader &&
           disable_email_click_tracking == o.disable_email_click_tracking &&
           include_unsubscribed == o.include_unsubscribed &&
+          email_bcc == o.email_bcc &&
           sms_from == o.sms_from &&
           sms_media_urls == o.sms_media_urls &&
           filters == o.filters &&
@@ -1228,7 +1256,7 @@ module OneSignal
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [id, value, name, aggregation, is_ios, is_android, is_huawei, is_any_web, is_chrome_web, is_firefox, is_safari, is_wp_wns, is_adm, is_chrome, app_id, external_id, idempotency_key, contents, headings, subtitle, data, huawei_msg_type, url, web_url, app_url, ios_attachments, template_id, content_available, mutable_content, target_content_identifier, big_picture, huawei_big_picture, adm_big_picture, chrome_big_picture, chrome_web_image, buttons, web_buttons, ios_category, android_channel_id, huawei_channel_id, existing_android_channel_id, huawei_existing_channel_id, android_background_layout, small_icon, huawei_small_icon, large_icon, huawei_large_icon, adm_small_icon, adm_large_icon, chrome_web_icon, chrome_web_badge, firefox_icon, chrome_icon, ios_sound, android_sound, huawei_sound, adm_sound, wp_wns_sound, android_led_color, huawei_led_color, android_accent_color, huawei_accent_color, android_visibility, huawei_visibility, ios_badge_type, ios_badge_count, collapse_id, web_push_topic, apns_alert, delayed_option, delivery_time_of_day, ttl, priority, apns_push_type_override, throttle_rate_per_minute, android_group, android_group_message, adm_group, adm_group_message, thread_id, summary_arg, summary_arg_count, ios_relevance_score, ios_interruption_level, email_subject, email_body, email_from_name, email_from_address, email_reply_to_address, email_preheader, disable_email_click_tracking, include_unsubscribed, sms_from, sms_media_urls, filters, custom_data, huawei_badge_class, huawei_badge_add_num, huawei_badge_set_num, huawei_category, huawei_bi_tag].hash
+      [id, value, name, aggregation, is_ios, is_android, is_huawei, is_any_web, is_chrome_web, is_firefox, is_safari, is_wp_wns, is_adm, is_chrome, app_id, external_id, idempotency_key, contents, headings, subtitle, data, huawei_msg_type, url, web_url, app_url, ios_attachments, template_id, content_available, mutable_content, target_content_identifier, big_picture, huawei_big_picture, adm_big_picture, chrome_big_picture, chrome_web_image, buttons, web_buttons, ios_category, android_channel_id, huawei_channel_id, existing_android_channel_id, huawei_existing_channel_id, android_background_layout, small_icon, huawei_small_icon, large_icon, huawei_large_icon, adm_small_icon, adm_large_icon, chrome_web_icon, chrome_web_badge, firefox_icon, chrome_icon, ios_sound, android_sound, huawei_sound, adm_sound, wp_wns_sound, android_led_color, huawei_led_color, android_accent_color, huawei_accent_color, android_visibility, huawei_visibility, ios_badge_type, ios_badge_count, collapse_id, web_push_topic, apns_alert, delayed_option, delivery_time_of_day, ttl, priority, apns_push_type_override, throttle_rate_per_minute, android_group, android_group_message, adm_group, adm_group_message, thread_id, summary_arg, summary_arg_count, ios_relevance_score, ios_interruption_level, email_subject, email_body, email_from_name, email_from_address, email_reply_to_address, email_preheader, disable_email_click_tracking, include_unsubscribed, email_bcc, sms_from, sms_media_urls, filters, custom_data, huawei_badge_class, huawei_badge_add_num, huawei_badge_set_num, huawei_category, huawei_bi_tag].hash
     end
 
     # Builds the object from hash

--- a/lib/onesignal/models/create_template_request.rb
+++ b/lib/onesignal/models/create_template_request.rb
@@ -36,6 +36,9 @@ module OneSignal
     # Body of the email (HTML supported).
     attr_accessor :email_body
 
+    # BCC recipients for the email template. Maximum 5 addresses. Only supported when the email service provider is OneSignal Email.
+    attr_accessor :email_bcc
+
     # Set true for an SMS template.
     attr_accessor :is_sms
 
@@ -53,6 +56,7 @@ module OneSignal
         :'is_email' => :'isEmail',
         :'email_subject' => :'email_subject',
         :'email_body' => :'email_body',
+        :'email_bcc' => :'email_bcc',
         :'is_sms' => :'isSMS',
         :'dynamic_content' => :'dynamic_content'
       }
@@ -74,6 +78,7 @@ module OneSignal
         :'is_email' => :'Boolean',
         :'email_subject' => :'String',
         :'email_body' => :'String',
+        :'email_bcc' => :'Array<String>',
         :'is_sms' => :'Boolean',
         :'dynamic_content' => :'String'
       }
@@ -84,6 +89,7 @@ module OneSignal
       Set.new([
         :'email_subject',
         :'email_body',
+        :'email_bcc',
         :'dynamic_content'
       ])
     end
@@ -135,6 +141,12 @@ module OneSignal
         self.email_body = attributes[:'email_body']
       end
 
+      if attributes.key?(:'email_bcc')
+        if (value = attributes[:'email_bcc']).is_a?(Array)
+          self.email_bcc = value
+        end
+      end
+
       if attributes.key?(:'is_sms')
         self.is_sms = attributes[:'is_sms']
       end
@@ -160,6 +172,10 @@ module OneSignal
         invalid_properties.push('invalid value for "contents", contents cannot be nil.')
       end
 
+      if !@email_bcc.nil? && @email_bcc.length > 5
+        invalid_properties.push('invalid value for "email_bcc", number of items must be less than or equal to 5.')
+      end
+
       invalid_properties
     end
 
@@ -169,7 +185,18 @@ module OneSignal
       return false if @app_id.nil?
       return false if @name.nil?
       return false if @contents.nil?
+      return false if !@email_bcc.nil? && @email_bcc.length > 5
       true
+    end
+
+    # Custom attribute writer method with validation
+    # @param [Object] email_bcc Value to be assigned
+    def email_bcc=(email_bcc)
+      if !email_bcc.nil? && email_bcc.length > 5
+        fail ArgumentError, 'invalid value for "email_bcc", number of items must be less than or equal to 5.'
+      end
+
+      @email_bcc = email_bcc
     end
 
     # Checks equality by comparing each attribute.
@@ -185,6 +212,7 @@ module OneSignal
           is_email == o.is_email &&
           email_subject == o.email_subject &&
           email_body == o.email_body &&
+          email_bcc == o.email_bcc &&
           is_sms == o.is_sms &&
           dynamic_content == o.dynamic_content
     end
@@ -198,7 +226,7 @@ module OneSignal
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [app_id, name, contents, headings, subtitle, is_email, email_subject, email_body, is_sms, dynamic_content].hash
+      [app_id, name, contents, headings, subtitle, is_email, email_subject, email_body, email_bcc, is_sms, dynamic_content].hash
     end
 
     # Builds the object from hash

--- a/lib/onesignal/models/notification.rb
+++ b/lib/onesignal/models/notification.rb
@@ -322,6 +322,9 @@ module OneSignal
     # Channel: Email Default is `false`. This field is used to send transactional notifications. If set to `true`, this notification will also be sent to unsubscribed emails. If a `template_id` is provided, the `include_unsubscribed` value from the template will be inherited. If you are using a third-party ESP, this field requires the ESP's list of unsubscribed emails to be cleared.
     attr_accessor :include_unsubscribed
 
+    # Channel: Email BCC recipients for the email. Maximum 5 addresses. Only supported when the email service provider is OneSignal Email. 
+    attr_accessor :email_bcc
+
     # Channel: SMS Phone Number used to send SMS. Should be a registered Twilio phone number in E.164 format. 
     attr_accessor :sms_from
 
@@ -481,6 +484,7 @@ module OneSignal
         :'email_preheader' => :'email_preheader',
         :'disable_email_click_tracking' => :'disable_email_click_tracking',
         :'include_unsubscribed' => :'include_unsubscribed',
+        :'email_bcc' => :'email_bcc',
         :'sms_from' => :'sms_from',
         :'sms_media_urls' => :'sms_media_urls',
         :'filters' => :'filters',
@@ -607,6 +611,7 @@ module OneSignal
         :'email_preheader' => :'String',
         :'disable_email_click_tracking' => :'Boolean',
         :'include_unsubscribed' => :'Boolean',
+        :'email_bcc' => :'Array<String>',
         :'sms_from' => :'String',
         :'sms_media_urls' => :'Array<String>',
         :'filters' => :'Array<FilterExpression>',
@@ -705,6 +710,7 @@ module OneSignal
         :'email_reply_to_address',
         :'email_preheader',
         :'disable_email_click_tracking',
+        :'email_bcc',
         :'sms_from',
         :'sms_media_urls',
         :'filters',
@@ -1189,6 +1195,12 @@ module OneSignal
         self.include_unsubscribed = attributes[:'include_unsubscribed']
       end
 
+      if attributes.key?(:'email_bcc')
+        if (value = attributes[:'email_bcc']).is_a?(Array)
+          self.email_bcc = value
+        end
+      end
+
       if attributes.key?(:'sms_from')
         self.sms_from = attributes[:'sms_from']
       end
@@ -1242,6 +1254,10 @@ module OneSignal
         invalid_properties.push('invalid value for "app_id", app_id cannot be nil.')
       end
 
+      if !@email_bcc.nil? && @email_bcc.length > 5
+        invalid_properties.push('invalid value for "email_bcc", number of items must be less than or equal to 5.')
+      end
+
       invalid_properties
     end
 
@@ -1253,6 +1269,7 @@ module OneSignal
       aggregation_validator = EnumAttributeValidator.new('String', ["sum", "count"])
       return false unless aggregation_validator.valid?(@aggregation)
       return false if @app_id.nil?
+      return false if !@email_bcc.nil? && @email_bcc.length > 5
       huawei_category_validator = EnumAttributeValidator.new('String', ["IM", "VOIP", "SUBSCRIPTION", "TRAVEL", "HEALTH", "WORK", "ACCOUNT", "EXPRESS", "FINANCE", "DEVICE_REMINDER", "MAIL", "MARKETING"])
       return false unless huawei_category_validator.valid?(@huawei_category)
       true
@@ -1276,6 +1293,16 @@ module OneSignal
         fail ArgumentError, "invalid value for \"aggregation\", must be one of #{validator.allowable_values}."
       end
       @aggregation = aggregation
+    end
+
+    # Custom attribute writer method with validation
+    # @param [Object] email_bcc Value to be assigned
+    def email_bcc=(email_bcc)
+      if !email_bcc.nil? && email_bcc.length > 5
+        fail ArgumentError, 'invalid value for "email_bcc", number of items must be less than or equal to 5.'
+      end
+
+      @email_bcc = email_bcc
     end
 
     # Custom attribute writer method checking allowed values (enum).
@@ -1398,6 +1425,7 @@ module OneSignal
           email_preheader == o.email_preheader &&
           disable_email_click_tracking == o.disable_email_click_tracking &&
           include_unsubscribed == o.include_unsubscribed &&
+          email_bcc == o.email_bcc &&
           sms_from == o.sms_from &&
           sms_media_urls == o.sms_media_urls &&
           filters == o.filters &&
@@ -1419,7 +1447,7 @@ module OneSignal
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [included_segments, excluded_segments, include_subscription_ids, include_email_tokens, include_phone_numbers, include_ios_tokens, include_wp_wns_uris, include_amazon_reg_ids, include_chrome_reg_ids, include_chrome_web_reg_ids, include_android_reg_ids, include_aliases, target_channel, id, value, name, aggregation, is_ios, is_android, is_huawei, is_any_web, is_chrome_web, is_firefox, is_safari, is_wp_wns, is_adm, is_chrome, app_id, external_id, idempotency_key, contents, headings, subtitle, data, huawei_msg_type, url, web_url, app_url, ios_attachments, template_id, content_available, mutable_content, target_content_identifier, big_picture, huawei_big_picture, adm_big_picture, chrome_big_picture, chrome_web_image, buttons, web_buttons, ios_category, android_channel_id, huawei_channel_id, existing_android_channel_id, huawei_existing_channel_id, android_background_layout, small_icon, huawei_small_icon, large_icon, huawei_large_icon, adm_small_icon, adm_large_icon, chrome_web_icon, chrome_web_badge, firefox_icon, chrome_icon, ios_sound, android_sound, huawei_sound, adm_sound, wp_wns_sound, android_led_color, huawei_led_color, android_accent_color, huawei_accent_color, android_visibility, huawei_visibility, ios_badge_type, ios_badge_count, collapse_id, web_push_topic, apns_alert, delayed_option, delivery_time_of_day, ttl, priority, apns_push_type_override, throttle_rate_per_minute, android_group, android_group_message, adm_group, adm_group_message, thread_id, summary_arg, summary_arg_count, ios_relevance_score, ios_interruption_level, email_subject, email_body, email_from_name, email_from_address, email_reply_to_address, email_preheader, disable_email_click_tracking, include_unsubscribed, sms_from, sms_media_urls, filters, custom_data, huawei_badge_class, huawei_badge_add_num, huawei_badge_set_num, huawei_category, huawei_bi_tag, send_after].hash
+      [included_segments, excluded_segments, include_subscription_ids, include_email_tokens, include_phone_numbers, include_ios_tokens, include_wp_wns_uris, include_amazon_reg_ids, include_chrome_reg_ids, include_chrome_web_reg_ids, include_android_reg_ids, include_aliases, target_channel, id, value, name, aggregation, is_ios, is_android, is_huawei, is_any_web, is_chrome_web, is_firefox, is_safari, is_wp_wns, is_adm, is_chrome, app_id, external_id, idempotency_key, contents, headings, subtitle, data, huawei_msg_type, url, web_url, app_url, ios_attachments, template_id, content_available, mutable_content, target_content_identifier, big_picture, huawei_big_picture, adm_big_picture, chrome_big_picture, chrome_web_image, buttons, web_buttons, ios_category, android_channel_id, huawei_channel_id, existing_android_channel_id, huawei_existing_channel_id, android_background_layout, small_icon, huawei_small_icon, large_icon, huawei_large_icon, adm_small_icon, adm_large_icon, chrome_web_icon, chrome_web_badge, firefox_icon, chrome_icon, ios_sound, android_sound, huawei_sound, adm_sound, wp_wns_sound, android_led_color, huawei_led_color, android_accent_color, huawei_accent_color, android_visibility, huawei_visibility, ios_badge_type, ios_badge_count, collapse_id, web_push_topic, apns_alert, delayed_option, delivery_time_of_day, ttl, priority, apns_push_type_override, throttle_rate_per_minute, android_group, android_group_message, adm_group, adm_group_message, thread_id, summary_arg, summary_arg_count, ios_relevance_score, ios_interruption_level, email_subject, email_body, email_from_name, email_from_address, email_reply_to_address, email_preheader, disable_email_click_tracking, include_unsubscribed, email_bcc, sms_from, sms_media_urls, filters, custom_data, huawei_badge_class, huawei_badge_add_num, huawei_badge_set_num, huawei_category, huawei_bi_tag, send_after].hash
     end
 
     # Builds the object from hash

--- a/lib/onesignal/models/notification_with_meta.rb
+++ b/lib/onesignal/models/notification_with_meta.rb
@@ -322,6 +322,9 @@ module OneSignal
     # Channel: Email Default is `false`. This field is used to send transactional notifications. If set to `true`, this notification will also be sent to unsubscribed emails. If a `template_id` is provided, the `include_unsubscribed` value from the template will be inherited. If you are using a third-party ESP, this field requires the ESP's list of unsubscribed emails to be cleared.
     attr_accessor :include_unsubscribed
 
+    # BCC recipients that were set on this email notification.
+    attr_accessor :email_bcc
+
     # Channel: SMS Phone Number used to send SMS. Should be a registered Twilio phone number in E.164 format. 
     attr_accessor :sms_from
 
@@ -381,6 +384,9 @@ module OneSignal
 
     # Indicates whether the notification was canceled before it could be sent.
     attr_accessor :canceled
+
+    # Number of BCC copies successfully sent for this notification.
+    attr_accessor :bcc_sent
 
     class EnumAttributeValidator
       attr_reader :datatype
@@ -512,6 +518,7 @@ module OneSignal
         :'email_preheader' => :'email_preheader',
         :'disable_email_click_tracking' => :'disable_email_click_tracking',
         :'include_unsubscribed' => :'include_unsubscribed',
+        :'email_bcc' => :'email_bcc',
         :'sms_from' => :'sms_from',
         :'sms_media_urls' => :'sms_media_urls',
         :'filters' => :'filters',
@@ -532,7 +539,8 @@ module OneSignal
         :'send_after' => :'send_after',
         :'completed_at' => :'completed_at',
         :'platform_delivery_stats' => :'platform_delivery_stats',
-        :'canceled' => :'canceled'
+        :'canceled' => :'canceled',
+        :'bcc_sent' => :'bcc_sent'
       }
     end
 
@@ -649,6 +657,7 @@ module OneSignal
         :'email_preheader' => :'String',
         :'disable_email_click_tracking' => :'Boolean',
         :'include_unsubscribed' => :'Boolean',
+        :'email_bcc' => :'Array<String>',
         :'sms_from' => :'String',
         :'sms_media_urls' => :'Array<String>',
         :'filters' => :'Array<FilterExpression>',
@@ -669,7 +678,8 @@ module OneSignal
         :'send_after' => :'Integer',
         :'completed_at' => :'Integer',
         :'platform_delivery_stats' => :'PlatformDeliveryData',
-        :'canceled' => :'Boolean'
+        :'canceled' => :'Boolean',
+        :'bcc_sent' => :'Integer'
       }
     end
 
@@ -758,6 +768,7 @@ module OneSignal
         :'email_reply_to_address',
         :'email_preheader',
         :'disable_email_click_tracking',
+        :'email_bcc',
         :'sms_from',
         :'sms_media_urls',
         :'filters',
@@ -770,6 +781,7 @@ module OneSignal
         :'received',
         :'send_after',
         :'completed_at',
+        :'bcc_sent'
       ])
     end
 
@@ -1246,6 +1258,12 @@ module OneSignal
         self.include_unsubscribed = attributes[:'include_unsubscribed']
       end
 
+      if attributes.key?(:'email_bcc')
+        if (value = attributes[:'email_bcc']).is_a?(Array)
+          self.email_bcc = value
+        end
+      end
+
       if attributes.key?(:'sms_from')
         self.sms_from = attributes[:'sms_from']
       end
@@ -1334,6 +1352,10 @@ module OneSignal
 
       if attributes.key?(:'canceled')
         self.canceled = attributes[:'canceled']
+      end
+
+      if attributes.key?(:'bcc_sent')
+        self.bcc_sent = attributes[:'bcc_sent']
       end
     end
 
@@ -1501,6 +1523,7 @@ module OneSignal
           email_preheader == o.email_preheader &&
           disable_email_click_tracking == o.disable_email_click_tracking &&
           include_unsubscribed == o.include_unsubscribed &&
+          email_bcc == o.email_bcc &&
           sms_from == o.sms_from &&
           sms_media_urls == o.sms_media_urls &&
           filters == o.filters &&
@@ -1521,7 +1544,8 @@ module OneSignal
           send_after == o.send_after &&
           completed_at == o.completed_at &&
           platform_delivery_stats == o.platform_delivery_stats &&
-          canceled == o.canceled
+          canceled == o.canceled &&
+          bcc_sent == o.bcc_sent
     end
 
     # @see the `==` method
@@ -1533,7 +1557,7 @@ module OneSignal
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [included_segments, excluded_segments, include_subscription_ids, include_email_tokens, include_phone_numbers, include_ios_tokens, include_wp_wns_uris, include_amazon_reg_ids, include_chrome_reg_ids, include_chrome_web_reg_ids, include_android_reg_ids, include_aliases, target_channel, id, value, name, aggregation, is_ios, is_android, is_huawei, is_any_web, is_chrome_web, is_firefox, is_safari, is_wp_wns, is_adm, is_chrome, app_id, external_id, idempotency_key, contents, headings, subtitle, data, huawei_msg_type, url, web_url, app_url, ios_attachments, template_id, content_available, mutable_content, target_content_identifier, big_picture, huawei_big_picture, adm_big_picture, chrome_big_picture, chrome_web_image, buttons, web_buttons, ios_category, android_channel_id, huawei_channel_id, existing_android_channel_id, huawei_existing_channel_id, android_background_layout, small_icon, huawei_small_icon, large_icon, huawei_large_icon, adm_small_icon, adm_large_icon, chrome_web_icon, chrome_web_badge, firefox_icon, chrome_icon, ios_sound, android_sound, huawei_sound, adm_sound, wp_wns_sound, android_led_color, huawei_led_color, android_accent_color, huawei_accent_color, android_visibility, huawei_visibility, ios_badge_type, ios_badge_count, collapse_id, web_push_topic, apns_alert, delayed_option, delivery_time_of_day, ttl, priority, apns_push_type_override, throttle_rate_per_minute, android_group, android_group_message, adm_group, adm_group_message, thread_id, summary_arg, summary_arg_count, ios_relevance_score, ios_interruption_level, email_subject, email_body, email_from_name, email_from_address, email_reply_to_address, email_preheader, disable_email_click_tracking, include_unsubscribed, sms_from, sms_media_urls, filters, custom_data, huawei_badge_class, huawei_badge_add_num, huawei_badge_set_num, huawei_category, huawei_bi_tag, successful, failed, errored, converted, received, outcomes, remaining, queued_at, send_after, completed_at, platform_delivery_stats, canceled].hash
+      [included_segments, excluded_segments, include_subscription_ids, include_email_tokens, include_phone_numbers, include_ios_tokens, include_wp_wns_uris, include_amazon_reg_ids, include_chrome_reg_ids, include_chrome_web_reg_ids, include_android_reg_ids, include_aliases, target_channel, id, value, name, aggregation, is_ios, is_android, is_huawei, is_any_web, is_chrome_web, is_firefox, is_safari, is_wp_wns, is_adm, is_chrome, app_id, external_id, idempotency_key, contents, headings, subtitle, data, huawei_msg_type, url, web_url, app_url, ios_attachments, template_id, content_available, mutable_content, target_content_identifier, big_picture, huawei_big_picture, adm_big_picture, chrome_big_picture, chrome_web_image, buttons, web_buttons, ios_category, android_channel_id, huawei_channel_id, existing_android_channel_id, huawei_existing_channel_id, android_background_layout, small_icon, huawei_small_icon, large_icon, huawei_large_icon, adm_small_icon, adm_large_icon, chrome_web_icon, chrome_web_badge, firefox_icon, chrome_icon, ios_sound, android_sound, huawei_sound, adm_sound, wp_wns_sound, android_led_color, huawei_led_color, android_accent_color, huawei_accent_color, android_visibility, huawei_visibility, ios_badge_type, ios_badge_count, collapse_id, web_push_topic, apns_alert, delayed_option, delivery_time_of_day, ttl, priority, apns_push_type_override, throttle_rate_per_minute, android_group, android_group_message, adm_group, adm_group_message, thread_id, summary_arg, summary_arg_count, ios_relevance_score, ios_interruption_level, email_subject, email_body, email_from_name, email_from_address, email_reply_to_address, email_preheader, disable_email_click_tracking, include_unsubscribed, email_bcc, sms_from, sms_media_urls, filters, custom_data, huawei_badge_class, huawei_badge_add_num, huawei_badge_set_num, huawei_category, huawei_bi_tag, successful, failed, errored, converted, received, outcomes, remaining, queued_at, send_after, completed_at, platform_delivery_stats, canceled, bcc_sent].hash
     end
 
     # Builds the object from hash

--- a/lib/onesignal/models/notification_with_meta_all_of.rb
+++ b/lib/onesignal/models/notification_with_meta_all_of.rb
@@ -50,6 +50,12 @@ module OneSignal
     # Indicates whether the notification was canceled before it could be sent.
     attr_accessor :canceled
 
+    # BCC recipients that were set on this email notification.
+    attr_accessor :email_bcc
+
+    # Number of BCC copies successfully sent for this notification.
+    attr_accessor :bcc_sent
+
     # Attribute mapping from ruby-style variable name to JSON key.
     def self.attribute_map
       {
@@ -64,7 +70,9 @@ module OneSignal
         :'platform_delivery_stats' => :'platform_delivery_stats',
         :'received' => :'received',
         :'throttle_rate_per_minute' => :'throttle_rate_per_minute',
-        :'canceled' => :'canceled'
+        :'canceled' => :'canceled',
+        :'email_bcc' => :'email_bcc',
+        :'bcc_sent' => :'bcc_sent'
       }
     end
 
@@ -87,7 +95,9 @@ module OneSignal
         :'platform_delivery_stats' => :'PlatformDeliveryData',
         :'received' => :'Integer',
         :'throttle_rate_per_minute' => :'Integer',
-        :'canceled' => :'Boolean'
+        :'canceled' => :'Boolean',
+        :'email_bcc' => :'Array<String>',
+        :'bcc_sent' => :'Integer'
       }
     end
 
@@ -98,6 +108,8 @@ module OneSignal
         :'completed_at',
         :'received',
         :'throttle_rate_per_minute',
+        :'email_bcc',
+        :'bcc_sent'
       ])
     end
 
@@ -163,6 +175,16 @@ module OneSignal
       if attributes.key?(:'canceled')
         self.canceled = attributes[:'canceled']
       end
+
+      if attributes.key?(:'email_bcc')
+        if (value = attributes[:'email_bcc']).is_a?(Array)
+          self.email_bcc = value
+        end
+      end
+
+      if attributes.key?(:'bcc_sent')
+        self.bcc_sent = attributes[:'bcc_sent']
+      end
     end
 
     # Show invalid properties with the reasons. Usually used together with valid?
@@ -194,7 +216,9 @@ module OneSignal
           platform_delivery_stats == o.platform_delivery_stats &&
           received == o.received &&
           throttle_rate_per_minute == o.throttle_rate_per_minute &&
-          canceled == o.canceled
+          canceled == o.canceled &&
+          email_bcc == o.email_bcc &&
+          bcc_sent == o.bcc_sent
     end
 
     # @see the `==` method
@@ -206,7 +230,7 @@ module OneSignal
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [remaining, successful, failed, errored, converted, queued_at, send_after, completed_at, platform_delivery_stats, received, throttle_rate_per_minute, canceled].hash
+      [remaining, successful, failed, errored, converted, queued_at, send_after, completed_at, platform_delivery_stats, received, throttle_rate_per_minute, canceled, email_bcc, bcc_sent].hash
     end
 
     # Builds the object from hash

--- a/lib/onesignal/models/update_template_request.rb
+++ b/lib/onesignal/models/update_template_request.rb
@@ -33,6 +33,9 @@ module OneSignal
     # Body of the email (HTML supported).
     attr_accessor :email_body
 
+    # BCC recipients for the email template. Maximum 5 addresses. Only supported when the email service provider is OneSignal Email.
+    attr_accessor :email_bcc
+
     # Set true for an SMS template.
     attr_accessor :is_sms
 
@@ -49,6 +52,7 @@ module OneSignal
         :'is_email' => :'isEmail',
         :'email_subject' => :'email_subject',
         :'email_body' => :'email_body',
+        :'email_bcc' => :'email_bcc',
         :'is_sms' => :'isSMS',
         :'dynamic_content' => :'dynamic_content'
       }
@@ -69,6 +73,7 @@ module OneSignal
         :'is_email' => :'Boolean',
         :'email_subject' => :'String',
         :'email_body' => :'String',
+        :'email_bcc' => :'Array<String>',
         :'is_sms' => :'Boolean',
         :'dynamic_content' => :'String'
       }
@@ -79,6 +84,7 @@ module OneSignal
       Set.new([
         :'email_subject',
         :'email_body',
+        :'email_bcc',
         :'dynamic_content'
       ])
     end
@@ -126,6 +132,12 @@ module OneSignal
         self.email_body = attributes[:'email_body']
       end
 
+      if attributes.key?(:'email_bcc')
+        if (value = attributes[:'email_bcc']).is_a?(Array)
+          self.email_bcc = value
+        end
+      end
+
       if attributes.key?(:'is_sms')
         self.is_sms = attributes[:'is_sms']
       end
@@ -139,13 +151,28 @@ module OneSignal
     # @return Array for valid properties with the reasons
     def list_invalid_properties
       invalid_properties = Array.new
+      if !@email_bcc.nil? && @email_bcc.length > 5
+        invalid_properties.push('invalid value for "email_bcc", number of items must be less than or equal to 5.')
+      end
+
       invalid_properties
     end
 
     # Check to see if the all the properties in the model are valid
     # @return true if the model is valid
     def valid?
+      return false if !@email_bcc.nil? && @email_bcc.length > 5
       true
+    end
+
+    # Custom attribute writer method with validation
+    # @param [Object] email_bcc Value to be assigned
+    def email_bcc=(email_bcc)
+      if !email_bcc.nil? && email_bcc.length > 5
+        fail ArgumentError, 'invalid value for "email_bcc", number of items must be less than or equal to 5.'
+      end
+
+      @email_bcc = email_bcc
     end
 
     # Checks equality by comparing each attribute.
@@ -160,6 +187,7 @@ module OneSignal
           is_email == o.is_email &&
           email_subject == o.email_subject &&
           email_body == o.email_body &&
+          email_bcc == o.email_bcc &&
           is_sms == o.is_sms &&
           dynamic_content == o.dynamic_content
     end
@@ -173,7 +201,7 @@ module OneSignal
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [name, contents, headings, subtitle, is_email, email_subject, email_body, is_sms, dynamic_content].hash
+      [name, contents, headings, subtitle, is_email, email_subject, email_body, email_bcc, is_sms, dynamic_content].hash
     end
 
     # Builds the object from hash

--- a/spec/models/basic_notification_all_of_spec.rb
+++ b/spec/models/basic_notification_all_of_spec.rb
@@ -581,6 +581,12 @@ describe OneSignal::BasicNotificationAllOf do
     end
   end
 
+  describe 'test attribute "email_bcc"' do
+    it 'should work' do
+      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
+    end
+  end
+
   describe 'test attribute "sms_from"' do
     it 'should work' do
       # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers

--- a/spec/models/basic_notification_spec.rb
+++ b/spec/models/basic_notification_spec.rb
@@ -663,6 +663,12 @@ describe OneSignal::BasicNotification do
     end
   end
 
+  describe 'test attribute "email_bcc"' do
+    it 'should work' do
+      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
+    end
+  end
+
   describe 'test attribute "sms_from"' do
     it 'should work' do
       # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers

--- a/spec/models/create_template_request_spec.rb
+++ b/spec/models/create_template_request_spec.rb
@@ -73,6 +73,12 @@ describe OneSignal::CreateTemplateRequest do
     end
   end
 
+  describe 'test attribute "email_bcc"' do
+    it 'should work' do
+      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
+    end
+  end
+
   describe 'test attribute "is_sms"' do
     it 'should work' do
       # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -663,6 +663,12 @@ describe OneSignal::Notification do
     end
   end
 
+  describe 'test attribute "email_bcc"' do
+    it 'should work' do
+      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
+    end
+  end
+
   describe 'test attribute "sms_from"' do
     it 'should work' do
       # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers

--- a/spec/models/notification_with_meta_all_of_spec.rb
+++ b/spec/models/notification_with_meta_all_of_spec.rb
@@ -97,4 +97,16 @@ describe OneSignal::NotificationWithMetaAllOf do
     end
   end
 
+  describe 'test attribute "email_bcc"' do
+    it 'should work' do
+      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
+    end
+  end
+
+  describe 'test attribute "bcc_sent"' do
+    it 'should work' do
+      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
+    end
+  end
+
 end

--- a/spec/models/notification_with_meta_spec.rb
+++ b/spec/models/notification_with_meta_spec.rb
@@ -663,6 +663,12 @@ describe OneSignal::NotificationWithMeta do
     end
   end
 
+  describe 'test attribute "email_bcc"' do
+    it 'should work' do
+      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
+    end
+  end
+
   describe 'test attribute "sms_from"' do
     it 'should work' do
       # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
@@ -788,6 +794,12 @@ describe OneSignal::NotificationWithMeta do
   end
 
   describe 'test attribute "canceled"' do
+    it 'should work' do
+      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
+    end
+  end
+
+  describe 'test attribute "bcc_sent"' do
     it 'should work' do
       # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
     end

--- a/spec/models/update_template_request_spec.rb
+++ b/spec/models/update_template_request_spec.rb
@@ -67,6 +67,12 @@ describe OneSignal::UpdateTemplateRequest do
     end
   end
 
+  describe 'test attribute "email_bcc"' do
+    it 'should work' do
+      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
+    end
+  end
+
   describe 'test attribute "is_sms"' do
     it 'should work' do
       # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers


### PR DESCRIPTION
## Release v5.4.0

### 🚀 Features
- feat: add flat create-notification doc examples via vendor extension
- feat: Add email bcc to API client libraries

### 🐛 Bug Fixes
- fix(ruby): remove redundant gem build step from release workflow
- fix(api): keep CreateNotificationSuccessResponse.errors polymorphic

### 📚 Docs
- docs(api): notification targeting DX and TypeScript doc pipeline (SDK-4395)

---
_Generated from [OneSignal/api-client-libraries@bc71af6...731c23e](https://github.com/OneSignal/api-client-libraries/compare/bc71af602529f22c0d442e3b60e585fb0ad14264...731c23e829e6ae22d94e605ab87b2a20468e8961)._