### PR TITLE
ci: remove RUBYGEMS_API_KEY from publish workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,5 +59,3 @@ jobs:
 
       - name: Publish to RubyGems
         uses: rubygems/release-gem@v1
-        env:
-          GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}


### PR DESCRIPTION
## Updates

- remove `RUBYGEMS_API_KEY` from publish workflow