### PR TITLE
feat: add v5.5.0 package updates

### DIFF
--- a/docs/BasicNotification.md
+++ b/docs/BasicNotification.md
@@ -7,7 +7,8 @@
 | **included_segments** | **Array&lt;String&gt;** | The segment names you want to target. Users in these segments will receive a notification. This targeting parameter is only compatible with excluded_segments. Example: [\&quot;Active Users\&quot;, \&quot;Inactive Users\&quot;]  | [optional] |
 | **excluded_segments** | **Array&lt;String&gt;** | Segment that will be excluded when sending. Users in these segments will not receive a notification, even if they were included in included_segments. This targeting parameter is only compatible with included_segments. Example: [\&quot;Active Users\&quot;, \&quot;Inactive Users\&quot;]  | [optional] |
 | **include_subscription_ids** | **Array&lt;String&gt;** | Specific subscription ids to send your notification to. _Does not require API Auth Key._ Not compatible with any other targeting parameters. Example: [\&quot;1dd608f2-c6a1-11e3-851d-000c2940e62c\&quot;] Limit of 2,000 entries per REST API call  | [optional] |
-| **include_email_tokens** | **Array&lt;String&gt;** | Recommended for Sending Emails - Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts Limit of 2,000 entries per REST API call  | [optional] |
+| **include_email_tokens** | **Array&lt;String&gt;** | Deprecated alias for &#x60;email_to&#x60;. Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts. Limit of 2,000 entries per REST API call. Prefer &#x60;email_to&#x60; in new integrations.  | [optional] |
+| **email_to** | **Array&lt;String&gt;** | Recommended for Sending Emails - Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts. Limit of 2,000 entries per REST API call. Supersedes the deprecated &#x60;include_email_tokens&#x60; field.  | [optional] |
 | **include_phone_numbers** | **Array&lt;String&gt;** | Recommended for Sending SMS - Target specific phone numbers. The phone number should be in the E.164 format. Phone number should be an existing subscriber on OneSignal. Refer our docs to learn how to add phone numbers to OneSignal. Example phone number: +1999999999 Limit of 2,000 entries per REST API call  | [optional] |
 | **include_ios_tokens** | **Array&lt;String&gt;** | Not Recommended: Please consider using include_subscription_ids or include_aliases instead. Target using iOS device tokens. Warning: Only works with Production tokens. All non-alphanumeric characters must be removed from each token. If a token does not correspond to an existing user, a new user will be created. Example: ce777617da7f548fe7a9ab6febb56cf39fba6d38203... Limit of 2,000 entries per REST API call  | [optional] |
 | **include_wp_wns_uris** | **Array&lt;String&gt;** | Not Recommended: Please consider using include_subscription_ids or include_aliases instead. Target using Windows URIs. If a token does not correspond to an existing user, a new user will be created. Example: http://s.notify.live.net/u/1/bn1/HmQAAACPaLDr-... Limit of 2,000 entries per REST API call  | [optional] |
@@ -110,6 +111,7 @@
 | **disable_email_click_tracking** | **Boolean** | Channel: Email Default is &#x60;false&#x60;. If set to &#x60;true&#x60;, the URLs sent within the email will not include link tracking and will be the same as originally set; otherwise, all the URLs in the email will be tracked. | [optional] |
 | **include_unsubscribed** | **Boolean** | Channel: Email Default is &#x60;false&#x60;. This field is used to send transactional notifications. If set to &#x60;true&#x60;, this notification will also be sent to unsubscribed emails. If a &#x60;template_id&#x60; is provided, the &#x60;include_unsubscribed&#x60; value from the template will be inherited. If you are using a third-party ESP, this field requires the ESP&#39;s list of unsubscribed emails to be cleared. | [optional] |
 | **email_bcc** | **Array&lt;String&gt;** | Channel: Email BCC recipients for the email. Maximum 5 addresses. Only supported when the email service provider is OneSignal Email.  | [optional] |
+| **email_sender_domain** | **String** | Channel: Email Sender domain to use for the email message. Overrides the default sender domain configured for the app. Only supported when the email service provider is OneSignal Email.  | [optional] |
 | **sms_from** | **String** | Channel: SMS Phone Number used to send SMS. Should be a registered Twilio phone number in E.164 format.  | [optional] |
 | **sms_media_urls** | **Array&lt;String&gt;** | Channel: SMS URLs for the media files to be attached to the SMS content. Limit: 10 media urls with a total max. size of 5MBs.  | [optional] |
 | **filters** | [**Array&lt;FilterExpression&gt;**](FilterExpression.md) |  | [optional] |
@@ -130,6 +132,7 @@ instance = OneSignal::BasicNotification.new(
   excluded_segments: null,
   include_subscription_ids: null,
   include_email_tokens: null,
+  email_to: null,
   include_phone_numbers: null,
   include_ios_tokens: null,
   include_wp_wns_uris: null,
@@ -232,6 +235,7 @@ instance = OneSignal::BasicNotification.new(
   disable_email_click_tracking: null,
   include_unsubscribed: null,
   email_bcc: null,
+  email_sender_domain: null,
   sms_from: null,
   sms_media_urls: null,
   filters: null,

--- a/docs/BasicNotificationAllOf.md
+++ b/docs/BasicNotificationAllOf.md
@@ -97,6 +97,7 @@
 | **disable_email_click_tracking** | **Boolean** | Channel: Email Default is &#x60;false&#x60;. If set to &#x60;true&#x60;, the URLs sent within the email will not include link tracking and will be the same as originally set; otherwise, all the URLs in the email will be tracked. | [optional] |
 | **include_unsubscribed** | **Boolean** | Channel: Email Default is &#x60;false&#x60;. This field is used to send transactional notifications. If set to &#x60;true&#x60;, this notification will also be sent to unsubscribed emails. If a &#x60;template_id&#x60; is provided, the &#x60;include_unsubscribed&#x60; value from the template will be inherited. If you are using a third-party ESP, this field requires the ESP&#39;s list of unsubscribed emails to be cleared. | [optional] |
 | **email_bcc** | **Array&lt;String&gt;** | Channel: Email BCC recipients for the email. Maximum 5 addresses. Only supported when the email service provider is OneSignal Email.  | [optional] |
+| **email_sender_domain** | **String** | Channel: Email Sender domain to use for the email message. Overrides the default sender domain configured for the app. Only supported when the email service provider is OneSignal Email.  | [optional] |
 | **sms_from** | **String** | Channel: SMS Phone Number used to send SMS. Should be a registered Twilio phone number in E.164 format.  | [optional] |
 | **sms_media_urls** | **Array&lt;String&gt;** | Channel: SMS URLs for the media files to be attached to the SMS content. Limit: 10 media urls with a total max. size of 5MBs.  | [optional] |
 | **filters** | [**Array&lt;FilterExpression&gt;**](FilterExpression.md) |  | [optional] |
@@ -206,6 +207,7 @@ instance = OneSignal::BasicNotificationAllOf.new(
   disable_email_click_tracking: null,
   include_unsubscribed: null,
   email_bcc: null,
+  email_sender_domain: null,
   sms_from: null,
   sms_media_urls: null,
   filters: null,

--- a/docs/Notification.md
+++ b/docs/Notification.md
@@ -7,7 +7,8 @@
 | **included_segments** | **Array&lt;String&gt;** | The segment names you want to target. Users in these segments will receive a notification. This targeting parameter is only compatible with excluded_segments. Example: [\&quot;Active Users\&quot;, \&quot;Inactive Users\&quot;]  | [optional] |
 | **excluded_segments** | **Array&lt;String&gt;** | Segment that will be excluded when sending. Users in these segments will not receive a notification, even if they were included in included_segments. This targeting parameter is only compatible with included_segments. Example: [\&quot;Active Users\&quot;, \&quot;Inactive Users\&quot;]  | [optional] |
 | **include_subscription_ids** | **Array&lt;String&gt;** | Specific subscription ids to send your notification to. _Does not require API Auth Key._ Not compatible with any other targeting parameters. Example: [\&quot;1dd608f2-c6a1-11e3-851d-000c2940e62c\&quot;] Limit of 2,000 entries per REST API call  | [optional] |
-| **include_email_tokens** | **Array&lt;String&gt;** | Recommended for Sending Emails - Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts Limit of 2,000 entries per REST API call  | [optional] |
+| **include_email_tokens** | **Array&lt;String&gt;** | Deprecated alias for &#x60;email_to&#x60;. Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts. Limit of 2,000 entries per REST API call. Prefer &#x60;email_to&#x60; in new integrations.  | [optional] |
+| **email_to** | **Array&lt;String&gt;** | Recommended for Sending Emails - Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts. Limit of 2,000 entries per REST API call. Supersedes the deprecated &#x60;include_email_tokens&#x60; field.  | [optional] |
 | **include_phone_numbers** | **Array&lt;String&gt;** | Recommended for Sending SMS - Target specific phone numbers. The phone number should be in the E.164 format. Phone number should be an existing subscriber on OneSignal. Refer our docs to learn how to add phone numbers to OneSignal. Example phone number: +1999999999 Limit of 2,000 entries per REST API call  | [optional] |
 | **include_ios_tokens** | **Array&lt;String&gt;** | Not Recommended: Please consider using include_subscription_ids or include_aliases instead. Target using iOS device tokens. Warning: Only works with Production tokens. All non-alphanumeric characters must be removed from each token. If a token does not correspond to an existing user, a new user will be created. Example: ce777617da7f548fe7a9ab6febb56cf39fba6d38203... Limit of 2,000 entries per REST API call  | [optional] |
 | **include_wp_wns_uris** | **Array&lt;String&gt;** | Not Recommended: Please consider using include_subscription_ids or include_aliases instead. Target using Windows URIs. If a token does not correspond to an existing user, a new user will be created. Example: http://s.notify.live.net/u/1/bn1/HmQAAACPaLDr-... Limit of 2,000 entries per REST API call  | [optional] |
@@ -110,6 +111,7 @@
 | **disable_email_click_tracking** | **Boolean** | Channel: Email Default is &#x60;false&#x60;. If set to &#x60;true&#x60;, the URLs sent within the email will not include link tracking and will be the same as originally set; otherwise, all the URLs in the email will be tracked. | [optional] |
 | **include_unsubscribed** | **Boolean** | Channel: Email Default is &#x60;false&#x60;. This field is used to send transactional notifications. If set to &#x60;true&#x60;, this notification will also be sent to unsubscribed emails. If a &#x60;template_id&#x60; is provided, the &#x60;include_unsubscribed&#x60; value from the template will be inherited. If you are using a third-party ESP, this field requires the ESP&#39;s list of unsubscribed emails to be cleared. | [optional] |
 | **email_bcc** | **Array&lt;String&gt;** | Channel: Email BCC recipients for the email. Maximum 5 addresses. Only supported when the email service provider is OneSignal Email.  | [optional] |
+| **email_sender_domain** | **String** | Channel: Email Sender domain to use for the email message. Overrides the default sender domain configured for the app. Only supported when the email service provider is OneSignal Email.  | [optional] |
 | **sms_from** | **String** | Channel: SMS Phone Number used to send SMS. Should be a registered Twilio phone number in E.164 format.  | [optional] |
 | **sms_media_urls** | **Array&lt;String&gt;** | Channel: SMS URLs for the media files to be attached to the SMS content. Limit: 10 media urls with a total max. size of 5MBs.  | [optional] |
 | **filters** | [**Array&lt;FilterExpression&gt;**](FilterExpression.md) |  | [optional] |
@@ -131,6 +133,7 @@ instance = OneSignal::Notification.new(
   excluded_segments: null,
   include_subscription_ids: null,
   include_email_tokens: null,
+  email_to: null,
   include_phone_numbers: null,
   include_ios_tokens: null,
   include_wp_wns_uris: null,
@@ -233,6 +236,7 @@ instance = OneSignal::Notification.new(
   disable_email_click_tracking: null,
   include_unsubscribed: null,
   email_bcc: null,
+  email_sender_domain: null,
   sms_from: null,
   sms_media_urls: null,
   filters: null,

--- a/docs/NotificationTarget.md
+++ b/docs/NotificationTarget.md
@@ -7,7 +7,8 @@
 | **included_segments** | **Array&lt;String&gt;** | The segment names you want to target. Users in these segments will receive a notification. This targeting parameter is only compatible with excluded_segments. Example: [\&quot;Active Users\&quot;, \&quot;Inactive Users\&quot;]  | [optional] |
 | **excluded_segments** | **Array&lt;String&gt;** | Segment that will be excluded when sending. Users in these segments will not receive a notification, even if they were included in included_segments. This targeting parameter is only compatible with included_segments. Example: [\&quot;Active Users\&quot;, \&quot;Inactive Users\&quot;]  | [optional] |
 | **include_subscription_ids** | **Array&lt;String&gt;** | Specific subscription ids to send your notification to. _Does not require API Auth Key._ Not compatible with any other targeting parameters. Example: [\&quot;1dd608f2-c6a1-11e3-851d-000c2940e62c\&quot;] Limit of 2,000 entries per REST API call  | [optional] |
-| **include_email_tokens** | **Array&lt;String&gt;** | Recommended for Sending Emails - Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts Limit of 2,000 entries per REST API call  | [optional] |
+| **include_email_tokens** | **Array&lt;String&gt;** | Deprecated alias for &#x60;email_to&#x60;. Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts. Limit of 2,000 entries per REST API call. Prefer &#x60;email_to&#x60; in new integrations.  | [optional] |
+| **email_to** | **Array&lt;String&gt;** | Recommended for Sending Emails - Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts. Limit of 2,000 entries per REST API call. Supersedes the deprecated &#x60;include_email_tokens&#x60; field.  | [optional] |
 | **include_phone_numbers** | **Array&lt;String&gt;** | Recommended for Sending SMS - Target specific phone numbers. The phone number should be in the E.164 format. Phone number should be an existing subscriber on OneSignal. Refer our docs to learn how to add phone numbers to OneSignal. Example phone number: +1999999999 Limit of 2,000 entries per REST API call  | [optional] |
 | **include_ios_tokens** | **Array&lt;String&gt;** | Not Recommended: Please consider using include_subscription_ids or include_aliases instead. Target using iOS device tokens. Warning: Only works with Production tokens. All non-alphanumeric characters must be removed from each token. If a token does not correspond to an existing user, a new user will be created. Example: ce777617da7f548fe7a9ab6febb56cf39fba6d38203... Limit of 2,000 entries per REST API call  | [optional] |
 | **include_wp_wns_uris** | **Array&lt;String&gt;** | Not Recommended: Please consider using include_subscription_ids or include_aliases instead. Target using Windows URIs. If a token does not correspond to an existing user, a new user will be created. Example: http://s.notify.live.net/u/1/bn1/HmQAAACPaLDr-... Limit of 2,000 entries per REST API call  | [optional] |
@@ -28,6 +29,7 @@ instance = OneSignal::NotificationTarget.new(
   excluded_segments: null,
   include_subscription_ids: null,
   include_email_tokens: null,
+  email_to: null,
   include_phone_numbers: null,
   include_ios_tokens: null,
   include_wp_wns_uris: null,

--- a/docs/NotificationWithMeta.md
+++ b/docs/NotificationWithMeta.md
@@ -7,7 +7,8 @@
 | **included_segments** | **Array&lt;String&gt;** | The segment names you want to target. Users in these segments will receive a notification. This targeting parameter is only compatible with excluded_segments. Example: [\&quot;Active Users\&quot;, \&quot;Inactive Users\&quot;]  | [optional] |
 | **excluded_segments** | **Array&lt;String&gt;** | Segment that will be excluded when sending. Users in these segments will not receive a notification, even if they were included in included_segments. This targeting parameter is only compatible with included_segments. Example: [\&quot;Active Users\&quot;, \&quot;Inactive Users\&quot;]  | [optional] |
 | **include_subscription_ids** | **Array&lt;String&gt;** | Specific subscription ids to send your notification to. _Does not require API Auth Key._ Not compatible with any other targeting parameters. Example: [\&quot;1dd608f2-c6a1-11e3-851d-000c2940e62c\&quot;] Limit of 2,000 entries per REST API call  | [optional] |
-| **include_email_tokens** | **Array&lt;String&gt;** | Recommended for Sending Emails - Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts Limit of 2,000 entries per REST API call  | [optional] |
+| **include_email_tokens** | **Array&lt;String&gt;** | Deprecated alias for &#x60;email_to&#x60;. Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts. Limit of 2,000 entries per REST API call. Prefer &#x60;email_to&#x60; in new integrations.  | [optional] |
+| **email_to** | **Array&lt;String&gt;** | Recommended for Sending Emails - Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts. Limit of 2,000 entries per REST API call. Supersedes the deprecated &#x60;include_email_tokens&#x60; field.  | [optional] |
 | **include_phone_numbers** | **Array&lt;String&gt;** | Recommended for Sending SMS - Target specific phone numbers. The phone number should be in the E.164 format. Phone number should be an existing subscriber on OneSignal. Refer our docs to learn how to add phone numbers to OneSignal. Example phone number: +1999999999 Limit of 2,000 entries per REST API call  | [optional] |
 | **include_ios_tokens** | **Array&lt;String&gt;** | Not Recommended: Please consider using include_subscription_ids or include_aliases instead. Target using iOS device tokens. Warning: Only works with Production tokens. All non-alphanumeric characters must be removed from each token. If a token does not correspond to an existing user, a new user will be created. Example: ce777617da7f548fe7a9ab6febb56cf39fba6d38203... Limit of 2,000 entries per REST API call  | [optional] |
 | **include_wp_wns_uris** | **Array&lt;String&gt;** | Not Recommended: Please consider using include_subscription_ids or include_aliases instead. Target using Windows URIs. If a token does not correspond to an existing user, a new user will be created. Example: http://s.notify.live.net/u/1/bn1/HmQAAACPaLDr-... Limit of 2,000 entries per REST API call  | [optional] |
@@ -110,6 +111,7 @@
 | **disable_email_click_tracking** | **Boolean** | Channel: Email Default is &#x60;false&#x60;. If set to &#x60;true&#x60;, the URLs sent within the email will not include link tracking and will be the same as originally set; otherwise, all the URLs in the email will be tracked. | [optional] |
 | **include_unsubscribed** | **Boolean** | Channel: Email Default is &#x60;false&#x60;. This field is used to send transactional notifications. If set to &#x60;true&#x60;, this notification will also be sent to unsubscribed emails. If a &#x60;template_id&#x60; is provided, the &#x60;include_unsubscribed&#x60; value from the template will be inherited. If you are using a third-party ESP, this field requires the ESP&#39;s list of unsubscribed emails to be cleared. | [optional] |
 | **email_bcc** | **Array&lt;String&gt;** | BCC recipients that were set on this email notification. | [optional] |
+| **email_sender_domain** | **String** | Channel: Email Sender domain to use for the email message. Overrides the default sender domain configured for the app. Only supported when the email service provider is OneSignal Email.  | [optional] |
 | **sms_from** | **String** | Channel: SMS Phone Number used to send SMS. Should be a registered Twilio phone number in E.164 format.  | [optional] |
 | **sms_media_urls** | **Array&lt;String&gt;** | Channel: SMS URLs for the media files to be attached to the SMS content. Limit: 10 media urls with a total max. size of 5MBs.  | [optional] |
 | **filters** | [**Array&lt;FilterExpression&gt;**](FilterExpression.md) |  | [optional] |
@@ -143,6 +145,7 @@ instance = OneSignal::NotificationWithMeta.new(
   excluded_segments: null,
   include_subscription_ids: null,
   include_email_tokens: null,
+  email_to: null,
   include_phone_numbers: null,
   include_ios_tokens: null,
   include_wp_wns_uris: null,
@@ -245,6 +248,7 @@ instance = OneSignal::NotificationWithMeta.new(
   disable_email_click_tracking: null,
   include_unsubscribed: null,
   email_bcc: null,
+  email_sender_domain: null,
   sms_from: null,
   sms_media_urls: null,
   filters: null,

--- a/docs/SubscriptionNotificationTarget.md
+++ b/docs/SubscriptionNotificationTarget.md
@@ -5,7 +5,8 @@
 | Name | Type | Description | Notes |
 | ---- | ---- | ----------- | ----- |
 | **include_subscription_ids** | **Array&lt;String&gt;** | Specific subscription ids to send your notification to. _Does not require API Auth Key._ Not compatible with any other targeting parameters. Example: [\&quot;1dd608f2-c6a1-11e3-851d-000c2940e62c\&quot;] Limit of 2,000 entries per REST API call  | [optional] |
-| **include_email_tokens** | **Array&lt;String&gt;** | Recommended for Sending Emails - Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts Limit of 2,000 entries per REST API call  | [optional] |
+| **include_email_tokens** | **Array&lt;String&gt;** | Deprecated alias for &#x60;email_to&#x60;. Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts. Limit of 2,000 entries per REST API call. Prefer &#x60;email_to&#x60; in new integrations.  | [optional] |
+| **email_to** | **Array&lt;String&gt;** | Recommended for Sending Emails - Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts. Limit of 2,000 entries per REST API call. Supersedes the deprecated &#x60;include_email_tokens&#x60; field.  | [optional] |
 | **include_phone_numbers** | **Array&lt;String&gt;** | Recommended for Sending SMS - Target specific phone numbers. The phone number should be in the E.164 format. Phone number should be an existing subscriber on OneSignal. Refer our docs to learn how to add phone numbers to OneSignal. Example phone number: +1999999999 Limit of 2,000 entries per REST API call  | [optional] |
 | **include_ios_tokens** | **Array&lt;String&gt;** | Not Recommended: Please consider using include_subscription_ids or include_aliases instead. Target using iOS device tokens. Warning: Only works with Production tokens. All non-alphanumeric characters must be removed from each token. If a token does not correspond to an existing user, a new user will be created. Example: ce777617da7f548fe7a9ab6febb56cf39fba6d38203... Limit of 2,000 entries per REST API call  | [optional] |
 | **include_wp_wns_uris** | **Array&lt;String&gt;** | Not Recommended: Please consider using include_subscription_ids or include_aliases instead. Target using Windows URIs. If a token does not correspond to an existing user, a new user will be created. Example: http://s.notify.live.net/u/1/bn1/HmQAAACPaLDr-... Limit of 2,000 entries per REST API call  | [optional] |
@@ -24,6 +25,7 @@ require 'onesignal'
 instance = OneSignal::SubscriptionNotificationTarget.new(
   include_subscription_ids: null,
   include_email_tokens: null,
+  email_to: null,
   include_phone_numbers: null,
   include_ios_tokens: null,
   include_wp_wns_uris: null,

--- a/lib/onesignal/models/basic_notification.rb
+++ b/lib/onesignal/models/basic_notification.rb
@@ -24,8 +24,11 @@ module OneSignal
     # Specific subscription ids to send your notification to. _Does not require API Auth Key._ Not compatible with any other targeting parameters. Example: [\"1dd608f2-c6a1-11e3-851d-000c2940e62c\"] Limit of 2,000 entries per REST API call 
     attr_accessor :include_subscription_ids
 
-    # Recommended for Sending Emails - Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts Limit of 2,000 entries per REST API call 
+    # Deprecated alias for `email_to`. Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts. Limit of 2,000 entries per REST API call. Prefer `email_to` in new integrations. 
     attr_accessor :include_email_tokens
+
+    # Recommended for Sending Emails - Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts. Limit of 2,000 entries per REST API call. Supersedes the deprecated `include_email_tokens` field. 
+    attr_accessor :email_to
 
     # Recommended for Sending SMS - Target specific phone numbers. The phone number should be in the E.164 format. Phone number should be an existing subscriber on OneSignal. Refer our docs to learn how to add phone numbers to OneSignal. Example phone number: +1999999999 Limit of 2,000 entries per REST API call 
     attr_accessor :include_phone_numbers
@@ -325,6 +328,9 @@ module OneSignal
     # Channel: Email BCC recipients for the email. Maximum 5 addresses. Only supported when the email service provider is OneSignal Email. 
     attr_accessor :email_bcc
 
+    # Channel: Email Sender domain to use for the email message. Overrides the default sender domain configured for the app. Only supported when the email service provider is OneSignal Email. 
+    attr_accessor :email_sender_domain
+
     # Channel: SMS Phone Number used to send SMS. Should be a registered Twilio phone number in E.164 format. 
     attr_accessor :sms_from
 
@@ -380,6 +386,7 @@ module OneSignal
         :'excluded_segments' => :'excluded_segments',
         :'include_subscription_ids' => :'include_subscription_ids',
         :'include_email_tokens' => :'include_email_tokens',
+        :'email_to' => :'email_to',
         :'include_phone_numbers' => :'include_phone_numbers',
         :'include_ios_tokens' => :'include_ios_tokens',
         :'include_wp_wns_uris' => :'include_wp_wns_uris',
@@ -482,6 +489,7 @@ module OneSignal
         :'disable_email_click_tracking' => :'disable_email_click_tracking',
         :'include_unsubscribed' => :'include_unsubscribed',
         :'email_bcc' => :'email_bcc',
+        :'email_sender_domain' => :'email_sender_domain',
         :'sms_from' => :'sms_from',
         :'sms_media_urls' => :'sms_media_urls',
         :'filters' => :'filters',
@@ -506,6 +514,7 @@ module OneSignal
         :'excluded_segments' => :'Array<String>',
         :'include_subscription_ids' => :'Array<String>',
         :'include_email_tokens' => :'Array<String>',
+        :'email_to' => :'Array<String>',
         :'include_phone_numbers' => :'Array<String>',
         :'include_ios_tokens' => :'Array<String>',
         :'include_wp_wns_uris' => :'Array<String>',
@@ -608,6 +617,7 @@ module OneSignal
         :'disable_email_click_tracking' => :'Boolean',
         :'include_unsubscribed' => :'Boolean',
         :'email_bcc' => :'Array<String>',
+        :'email_sender_domain' => :'String',
         :'sms_from' => :'String',
         :'sms_media_urls' => :'Array<String>',
         :'filters' => :'Array<FilterExpression>',
@@ -706,6 +716,7 @@ module OneSignal
         :'email_preheader',
         :'disable_email_click_tracking',
         :'email_bcc',
+        :'email_sender_domain',
         :'sms_from',
         :'sms_media_urls',
         :'filters',
@@ -762,6 +773,12 @@ module OneSignal
       if attributes.key?(:'include_email_tokens')
         if (value = attributes[:'include_email_tokens']).is_a?(Array)
           self.include_email_tokens = value
+        end
+      end
+
+      if attributes.key?(:'email_to')
+        if (value = attributes[:'email_to']).is_a?(Array)
+          self.email_to = value
         end
       end
 
@@ -1195,6 +1212,10 @@ module OneSignal
         end
       end
 
+      if attributes.key?(:'email_sender_domain')
+        self.email_sender_domain = attributes[:'email_sender_domain']
+      end
+
       if attributes.key?(:'sms_from')
         self.sms_from = attributes[:'sms_from']
       end
@@ -1314,6 +1335,7 @@ module OneSignal
           excluded_segments == o.excluded_segments &&
           include_subscription_ids == o.include_subscription_ids &&
           include_email_tokens == o.include_email_tokens &&
+          email_to == o.email_to &&
           include_phone_numbers == o.include_phone_numbers &&
           include_ios_tokens == o.include_ios_tokens &&
           include_wp_wns_uris == o.include_wp_wns_uris &&
@@ -1416,6 +1438,7 @@ module OneSignal
           disable_email_click_tracking == o.disable_email_click_tracking &&
           include_unsubscribed == o.include_unsubscribed &&
           email_bcc == o.email_bcc &&
+          email_sender_domain == o.email_sender_domain &&
           sms_from == o.sms_from &&
           sms_media_urls == o.sms_media_urls &&
           filters == o.filters &&
@@ -1436,7 +1459,7 @@ module OneSignal
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [included_segments, excluded_segments, include_subscription_ids, include_email_tokens, include_phone_numbers, include_ios_tokens, include_wp_wns_uris, include_amazon_reg_ids, include_chrome_reg_ids, include_chrome_web_reg_ids, include_android_reg_ids, include_aliases, target_channel, id, value, name, aggregation, is_ios, is_android, is_huawei, is_any_web, is_chrome_web, is_firefox, is_safari, is_wp_wns, is_adm, is_chrome, app_id, external_id, idempotency_key, contents, headings, subtitle, data, huawei_msg_type, url, web_url, app_url, ios_attachments, template_id, content_available, mutable_content, target_content_identifier, big_picture, huawei_big_picture, adm_big_picture, chrome_big_picture, chrome_web_image, buttons, web_buttons, ios_category, android_channel_id, huawei_channel_id, existing_android_channel_id, huawei_existing_channel_id, android_background_layout, small_icon, huawei_small_icon, large_icon, huawei_large_icon, adm_small_icon, adm_large_icon, chrome_web_icon, chrome_web_badge, firefox_icon, chrome_icon, ios_sound, android_sound, huawei_sound, adm_sound, wp_wns_sound, android_led_color, huawei_led_color, android_accent_color, huawei_accent_color, android_visibility, huawei_visibility, ios_badge_type, ios_badge_count, collapse_id, web_push_topic, apns_alert, delayed_option, delivery_time_of_day, ttl, priority, apns_push_type_override, throttle_rate_per_minute, android_group, android_group_message, adm_group, adm_group_message, thread_id, summary_arg, summary_arg_count, ios_relevance_score, ios_interruption_level, email_subject, email_body, email_from_name, email_from_address, email_reply_to_address, email_preheader, disable_email_click_tracking, include_unsubscribed, email_bcc, sms_from, sms_media_urls, filters, custom_data, huawei_badge_class, huawei_badge_add_num, huawei_badge_set_num, huawei_category, huawei_bi_tag].hash
+      [included_segments, excluded_segments, include_subscription_ids, include_email_tokens, email_to, include_phone_numbers, include_ios_tokens, include_wp_wns_uris, include_amazon_reg_ids, include_chrome_reg_ids, include_chrome_web_reg_ids, include_android_reg_ids, include_aliases, target_channel, id, value, name, aggregation, is_ios, is_android, is_huawei, is_any_web, is_chrome_web, is_firefox, is_safari, is_wp_wns, is_adm, is_chrome, app_id, external_id, idempotency_key, contents, headings, subtitle, data, huawei_msg_type, url, web_url, app_url, ios_attachments, template_id, content_available, mutable_content, target_content_identifier, big_picture, huawei_big_picture, adm_big_picture, chrome_big_picture, chrome_web_image, buttons, web_buttons, ios_category, android_channel_id, huawei_channel_id, existing_android_channel_id, huawei_existing_channel_id, android_background_layout, small_icon, huawei_small_icon, large_icon, huawei_large_icon, adm_small_icon, adm_large_icon, chrome_web_icon, chrome_web_badge, firefox_icon, chrome_icon, ios_sound, android_sound, huawei_sound, adm_sound, wp_wns_sound, android_led_color, huawei_led_color, android_accent_color, huawei_accent_color, android_visibility, huawei_visibility, ios_badge_type, ios_badge_count, collapse_id, web_push_topic, apns_alert, delayed_option, delivery_time_of_day, ttl, priority, apns_push_type_override, throttle_rate_per_minute, android_group, android_group_message, adm_group, adm_group_message, thread_id, summary_arg, summary_arg_count, ios_relevance_score, ios_interruption_level, email_subject, email_body, email_from_name, email_from_address, email_reply_to_address, email_preheader, disable_email_click_tracking, include_unsubscribed, email_bcc, email_sender_domain, sms_from, sms_media_urls, filters, custom_data, huawei_badge_class, huawei_badge_add_num, huawei_badge_set_num, huawei_category, huawei_bi_tag].hash
     end
 
     # Builds the object from hash

--- a/lib/onesignal/models/basic_notification_all_of.rb
+++ b/lib/onesignal/models/basic_notification_all_of.rb
@@ -287,6 +287,9 @@ module OneSignal
     # Channel: Email BCC recipients for the email. Maximum 5 addresses. Only supported when the email service provider is OneSignal Email. 
     attr_accessor :email_bcc
 
+    # Channel: Email Sender domain to use for the email message. Overrides the default sender domain configured for the app. Only supported when the email service provider is OneSignal Email. 
+    attr_accessor :email_sender_domain
+
     # Channel: SMS Phone Number used to send SMS. Should be a registered Twilio phone number in E.164 format. 
     attr_accessor :sms_from
 
@@ -431,6 +434,7 @@ module OneSignal
         :'disable_email_click_tracking' => :'disable_email_click_tracking',
         :'include_unsubscribed' => :'include_unsubscribed',
         :'email_bcc' => :'email_bcc',
+        :'email_sender_domain' => :'email_sender_domain',
         :'sms_from' => :'sms_from',
         :'sms_media_urls' => :'sms_media_urls',
         :'filters' => :'filters',
@@ -544,6 +548,7 @@ module OneSignal
         :'disable_email_click_tracking' => :'Boolean',
         :'include_unsubscribed' => :'Boolean',
         :'email_bcc' => :'Array<String>',
+        :'email_sender_domain' => :'String',
         :'sms_from' => :'String',
         :'sms_media_urls' => :'Array<String>',
         :'filters' => :'Array<FilterExpression>',
@@ -640,6 +645,7 @@ module OneSignal
         :'email_preheader',
         :'disable_email_click_tracking',
         :'email_bcc',
+        :'email_sender_domain',
         :'sms_from',
         :'sms_media_urls',
         :'filters',
@@ -1045,6 +1051,10 @@ module OneSignal
         end
       end
 
+      if attributes.key?(:'email_sender_domain')
+        self.email_sender_domain = attributes[:'email_sender_domain']
+      end
+
       if attributes.key?(:'sms_from')
         self.sms_from = attributes[:'sms_from']
       end
@@ -1236,6 +1246,7 @@ module OneSignal
           disable_email_click_tracking == o.disable_email_click_tracking &&
           include_unsubscribed == o.include_unsubscribed &&
           email_bcc == o.email_bcc &&
+          email_sender_domain == o.email_sender_domain &&
           sms_from == o.sms_from &&
           sms_media_urls == o.sms_media_urls &&
           filters == o.filters &&
@@ -1256,7 +1267,7 @@ module OneSignal
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [id, value, name, aggregation, is_ios, is_android, is_huawei, is_any_web, is_chrome_web, is_firefox, is_safari, is_wp_wns, is_adm, is_chrome, app_id, external_id, idempotency_key, contents, headings, subtitle, data, huawei_msg_type, url, web_url, app_url, ios_attachments, template_id, content_available, mutable_content, target_content_identifier, big_picture, huawei_big_picture, adm_big_picture, chrome_big_picture, chrome_web_image, buttons, web_buttons, ios_category, android_channel_id, huawei_channel_id, existing_android_channel_id, huawei_existing_channel_id, android_background_layout, small_icon, huawei_small_icon, large_icon, huawei_large_icon, adm_small_icon, adm_large_icon, chrome_web_icon, chrome_web_badge, firefox_icon, chrome_icon, ios_sound, android_sound, huawei_sound, adm_sound, wp_wns_sound, android_led_color, huawei_led_color, android_accent_color, huawei_accent_color, android_visibility, huawei_visibility, ios_badge_type, ios_badge_count, collapse_id, web_push_topic, apns_alert, delayed_option, delivery_time_of_day, ttl, priority, apns_push_type_override, throttle_rate_per_minute, android_group, android_group_message, adm_group, adm_group_message, thread_id, summary_arg, summary_arg_count, ios_relevance_score, ios_interruption_level, email_subject, email_body, email_from_name, email_from_address, email_reply_to_address, email_preheader, disable_email_click_tracking, include_unsubscribed, email_bcc, sms_from, sms_media_urls, filters, custom_data, huawei_badge_class, huawei_badge_add_num, huawei_badge_set_num, huawei_category, huawei_bi_tag].hash
+      [id, value, name, aggregation, is_ios, is_android, is_huawei, is_any_web, is_chrome_web, is_firefox, is_safari, is_wp_wns, is_adm, is_chrome, app_id, external_id, idempotency_key, contents, headings, subtitle, data, huawei_msg_type, url, web_url, app_url, ios_attachments, template_id, content_available, mutable_content, target_content_identifier, big_picture, huawei_big_picture, adm_big_picture, chrome_big_picture, chrome_web_image, buttons, web_buttons, ios_category, android_channel_id, huawei_channel_id, existing_android_channel_id, huawei_existing_channel_id, android_background_layout, small_icon, huawei_small_icon, large_icon, huawei_large_icon, adm_small_icon, adm_large_icon, chrome_web_icon, chrome_web_badge, firefox_icon, chrome_icon, ios_sound, android_sound, huawei_sound, adm_sound, wp_wns_sound, android_led_color, huawei_led_color, android_accent_color, huawei_accent_color, android_visibility, huawei_visibility, ios_badge_type, ios_badge_count, collapse_id, web_push_topic, apns_alert, delayed_option, delivery_time_of_day, ttl, priority, apns_push_type_override, throttle_rate_per_minute, android_group, android_group_message, adm_group, adm_group_message, thread_id, summary_arg, summary_arg_count, ios_relevance_score, ios_interruption_level, email_subject, email_body, email_from_name, email_from_address, email_reply_to_address, email_preheader, disable_email_click_tracking, include_unsubscribed, email_bcc, email_sender_domain, sms_from, sms_media_urls, filters, custom_data, huawei_badge_class, huawei_badge_add_num, huawei_badge_set_num, huawei_category, huawei_bi_tag].hash
     end
 
     # Builds the object from hash

--- a/lib/onesignal/models/notification.rb
+++ b/lib/onesignal/models/notification.rb
@@ -24,8 +24,11 @@ module OneSignal
     # Specific subscription ids to send your notification to. _Does not require API Auth Key._ Not compatible with any other targeting parameters. Example: [\"1dd608f2-c6a1-11e3-851d-000c2940e62c\"] Limit of 2,000 entries per REST API call 
     attr_accessor :include_subscription_ids
 
-    # Recommended for Sending Emails - Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts Limit of 2,000 entries per REST API call 
+    # Deprecated alias for `email_to`. Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts. Limit of 2,000 entries per REST API call. Prefer `email_to` in new integrations. 
     attr_accessor :include_email_tokens
+
+    # Recommended for Sending Emails - Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts. Limit of 2,000 entries per REST API call. Supersedes the deprecated `include_email_tokens` field. 
+    attr_accessor :email_to
 
     # Recommended for Sending SMS - Target specific phone numbers. The phone number should be in the E.164 format. Phone number should be an existing subscriber on OneSignal. Refer our docs to learn how to add phone numbers to OneSignal. Example phone number: +1999999999 Limit of 2,000 entries per REST API call 
     attr_accessor :include_phone_numbers
@@ -325,6 +328,9 @@ module OneSignal
     # Channel: Email BCC recipients for the email. Maximum 5 addresses. Only supported when the email service provider is OneSignal Email. 
     attr_accessor :email_bcc
 
+    # Channel: Email Sender domain to use for the email message. Overrides the default sender domain configured for the app. Only supported when the email service provider is OneSignal Email. 
+    attr_accessor :email_sender_domain
+
     # Channel: SMS Phone Number used to send SMS. Should be a registered Twilio phone number in E.164 format. 
     attr_accessor :sms_from
 
@@ -383,6 +389,7 @@ module OneSignal
         :'excluded_segments' => :'excluded_segments',
         :'include_subscription_ids' => :'include_subscription_ids',
         :'include_email_tokens' => :'include_email_tokens',
+        :'email_to' => :'email_to',
         :'include_phone_numbers' => :'include_phone_numbers',
         :'include_ios_tokens' => :'include_ios_tokens',
         :'include_wp_wns_uris' => :'include_wp_wns_uris',
@@ -485,6 +492,7 @@ module OneSignal
         :'disable_email_click_tracking' => :'disable_email_click_tracking',
         :'include_unsubscribed' => :'include_unsubscribed',
         :'email_bcc' => :'email_bcc',
+        :'email_sender_domain' => :'email_sender_domain',
         :'sms_from' => :'sms_from',
         :'sms_media_urls' => :'sms_media_urls',
         :'filters' => :'filters',
@@ -510,6 +518,7 @@ module OneSignal
         :'excluded_segments' => :'Array<String>',
         :'include_subscription_ids' => :'Array<String>',
         :'include_email_tokens' => :'Array<String>',
+        :'email_to' => :'Array<String>',
         :'include_phone_numbers' => :'Array<String>',
         :'include_ios_tokens' => :'Array<String>',
         :'include_wp_wns_uris' => :'Array<String>',
@@ -612,6 +621,7 @@ module OneSignal
         :'disable_email_click_tracking' => :'Boolean',
         :'include_unsubscribed' => :'Boolean',
         :'email_bcc' => :'Array<String>',
+        :'email_sender_domain' => :'String',
         :'sms_from' => :'String',
         :'sms_media_urls' => :'Array<String>',
         :'filters' => :'Array<FilterExpression>',
@@ -711,6 +721,7 @@ module OneSignal
         :'email_preheader',
         :'disable_email_click_tracking',
         :'email_bcc',
+        :'email_sender_domain',
         :'sms_from',
         :'sms_media_urls',
         :'filters',
@@ -768,6 +779,12 @@ module OneSignal
       if attributes.key?(:'include_email_tokens')
         if (value = attributes[:'include_email_tokens']).is_a?(Array)
           self.include_email_tokens = value
+        end
+      end
+
+      if attributes.key?(:'email_to')
+        if (value = attributes[:'email_to']).is_a?(Array)
+          self.email_to = value
         end
       end
 
@@ -1201,6 +1218,10 @@ module OneSignal
         end
       end
 
+      if attributes.key?(:'email_sender_domain')
+        self.email_sender_domain = attributes[:'email_sender_domain']
+      end
+
       if attributes.key?(:'sms_from')
         self.sms_from = attributes[:'sms_from']
       end
@@ -1324,6 +1345,7 @@ module OneSignal
           excluded_segments == o.excluded_segments &&
           include_subscription_ids == o.include_subscription_ids &&
           include_email_tokens == o.include_email_tokens &&
+          email_to == o.email_to &&
           include_phone_numbers == o.include_phone_numbers &&
           include_ios_tokens == o.include_ios_tokens &&
           include_wp_wns_uris == o.include_wp_wns_uris &&
@@ -1426,6 +1448,7 @@ module OneSignal
           disable_email_click_tracking == o.disable_email_click_tracking &&
           include_unsubscribed == o.include_unsubscribed &&
           email_bcc == o.email_bcc &&
+          email_sender_domain == o.email_sender_domain &&
           sms_from == o.sms_from &&
           sms_media_urls == o.sms_media_urls &&
           filters == o.filters &&
@@ -1447,7 +1470,7 @@ module OneSignal
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [included_segments, excluded_segments, include_subscription_ids, include_email_tokens, include_phone_numbers, include_ios_tokens, include_wp_wns_uris, include_amazon_reg_ids, include_chrome_reg_ids, include_chrome_web_reg_ids, include_android_reg_ids, include_aliases, target_channel, id, value, name, aggregation, is_ios, is_android, is_huawei, is_any_web, is_chrome_web, is_firefox, is_safari, is_wp_wns, is_adm, is_chrome, app_id, external_id, idempotency_key, contents, headings, subtitle, data, huawei_msg_type, url, web_url, app_url, ios_attachments, template_id, content_available, mutable_content, target_content_identifier, big_picture, huawei_big_picture, adm_big_picture, chrome_big_picture, chrome_web_image, buttons, web_buttons, ios_category, android_channel_id, huawei_channel_id, existing_android_channel_id, huawei_existing_channel_id, android_background_layout, small_icon, huawei_small_icon, large_icon, huawei_large_icon, adm_small_icon, adm_large_icon, chrome_web_icon, chrome_web_badge, firefox_icon, chrome_icon, ios_sound, android_sound, huawei_sound, adm_sound, wp_wns_sound, android_led_color, huawei_led_color, android_accent_color, huawei_accent_color, android_visibility, huawei_visibility, ios_badge_type, ios_badge_count, collapse_id, web_push_topic, apns_alert, delayed_option, delivery_time_of_day, ttl, priority, apns_push_type_override, throttle_rate_per_minute, android_group, android_group_message, adm_group, adm_group_message, thread_id, summary_arg, summary_arg_count, ios_relevance_score, ios_interruption_level, email_subject, email_body, email_from_name, email_from_address, email_reply_to_address, email_preheader, disable_email_click_tracking, include_unsubscribed, email_bcc, sms_from, sms_media_urls, filters, custom_data, huawei_badge_class, huawei_badge_add_num, huawei_badge_set_num, huawei_category, huawei_bi_tag, send_after].hash
+      [included_segments, excluded_segments, include_subscription_ids, include_email_tokens, email_to, include_phone_numbers, include_ios_tokens, include_wp_wns_uris, include_amazon_reg_ids, include_chrome_reg_ids, include_chrome_web_reg_ids, include_android_reg_ids, include_aliases, target_channel, id, value, name, aggregation, is_ios, is_android, is_huawei, is_any_web, is_chrome_web, is_firefox, is_safari, is_wp_wns, is_adm, is_chrome, app_id, external_id, idempotency_key, contents, headings, subtitle, data, huawei_msg_type, url, web_url, app_url, ios_attachments, template_id, content_available, mutable_content, target_content_identifier, big_picture, huawei_big_picture, adm_big_picture, chrome_big_picture, chrome_web_image, buttons, web_buttons, ios_category, android_channel_id, huawei_channel_id, existing_android_channel_id, huawei_existing_channel_id, android_background_layout, small_icon, huawei_small_icon, large_icon, huawei_large_icon, adm_small_icon, adm_large_icon, chrome_web_icon, chrome_web_badge, firefox_icon, chrome_icon, ios_sound, android_sound, huawei_sound, adm_sound, wp_wns_sound, android_led_color, huawei_led_color, android_accent_color, huawei_accent_color, android_visibility, huawei_visibility, ios_badge_type, ios_badge_count, collapse_id, web_push_topic, apns_alert, delayed_option, delivery_time_of_day, ttl, priority, apns_push_type_override, throttle_rate_per_minute, android_group, android_group_message, adm_group, adm_group_message, thread_id, summary_arg, summary_arg_count, ios_relevance_score, ios_interruption_level, email_subject, email_body, email_from_name, email_from_address, email_reply_to_address, email_preheader, disable_email_click_tracking, include_unsubscribed, email_bcc, email_sender_domain, sms_from, sms_media_urls, filters, custom_data, huawei_badge_class, huawei_badge_add_num, huawei_badge_set_num, huawei_category, huawei_bi_tag, send_after].hash
     end
 
     # Builds the object from hash

--- a/lib/onesignal/models/notification_target.rb
+++ b/lib/onesignal/models/notification_target.rb
@@ -24,8 +24,11 @@ module OneSignal
     # Specific subscription ids to send your notification to. _Does not require API Auth Key._ Not compatible with any other targeting parameters. Example: [\"1dd608f2-c6a1-11e3-851d-000c2940e62c\"] Limit of 2,000 entries per REST API call 
     attr_accessor :include_subscription_ids
 
-    # Recommended for Sending Emails - Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts Limit of 2,000 entries per REST API call 
+    # Deprecated alias for `email_to`. Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts. Limit of 2,000 entries per REST API call. Prefer `email_to` in new integrations. 
     attr_accessor :include_email_tokens
+
+    # Recommended for Sending Emails - Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts. Limit of 2,000 entries per REST API call. Supersedes the deprecated `include_email_tokens` field. 
+    attr_accessor :email_to
 
     # Recommended for Sending SMS - Target specific phone numbers. The phone number should be in the E.164 format. Phone number should be an existing subscriber on OneSignal. Refer our docs to learn how to add phone numbers to OneSignal. Example phone number: +1999999999 Limit of 2,000 entries per REST API call 
     attr_accessor :include_phone_numbers
@@ -82,6 +85,7 @@ module OneSignal
         :'excluded_segments' => :'excluded_segments',
         :'include_subscription_ids' => :'include_subscription_ids',
         :'include_email_tokens' => :'include_email_tokens',
+        :'email_to' => :'email_to',
         :'include_phone_numbers' => :'include_phone_numbers',
         :'include_ios_tokens' => :'include_ios_tokens',
         :'include_wp_wns_uris' => :'include_wp_wns_uris',
@@ -106,6 +110,7 @@ module OneSignal
         :'excluded_segments' => :'Array<String>',
         :'include_subscription_ids' => :'Array<String>',
         :'include_email_tokens' => :'Array<String>',
+        :'email_to' => :'Array<String>',
         :'include_phone_numbers' => :'Array<String>',
         :'include_ios_tokens' => :'Array<String>',
         :'include_wp_wns_uris' => :'Array<String>',
@@ -170,6 +175,12 @@ module OneSignal
       if attributes.key?(:'include_email_tokens')
         if (value = attributes[:'include_email_tokens']).is_a?(Array)
           self.include_email_tokens = value
+        end
+      end
+
+      if attributes.key?(:'email_to')
+        if (value = attributes[:'email_to']).is_a?(Array)
+          self.email_to = value
         end
       end
 
@@ -272,6 +283,7 @@ module OneSignal
           excluded_segments == o.excluded_segments &&
           include_subscription_ids == o.include_subscription_ids &&
           include_email_tokens == o.include_email_tokens &&
+          email_to == o.email_to &&
           include_phone_numbers == o.include_phone_numbers &&
           include_ios_tokens == o.include_ios_tokens &&
           include_wp_wns_uris == o.include_wp_wns_uris &&
@@ -292,7 +304,7 @@ module OneSignal
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [included_segments, excluded_segments, include_subscription_ids, include_email_tokens, include_phone_numbers, include_ios_tokens, include_wp_wns_uris, include_amazon_reg_ids, include_chrome_reg_ids, include_chrome_web_reg_ids, include_android_reg_ids, include_aliases, target_channel].hash
+      [included_segments, excluded_segments, include_subscription_ids, include_email_tokens, email_to, include_phone_numbers, include_ios_tokens, include_wp_wns_uris, include_amazon_reg_ids, include_chrome_reg_ids, include_chrome_web_reg_ids, include_android_reg_ids, include_aliases, target_channel].hash
     end
 
     # Builds the object from hash

--- a/lib/onesignal/models/notification_with_meta.rb
+++ b/lib/onesignal/models/notification_with_meta.rb
@@ -24,8 +24,11 @@ module OneSignal
     # Specific subscription ids to send your notification to. _Does not require API Auth Key._ Not compatible with any other targeting parameters. Example: [\"1dd608f2-c6a1-11e3-851d-000c2940e62c\"] Limit of 2,000 entries per REST API call 
     attr_accessor :include_subscription_ids
 
-    # Recommended for Sending Emails - Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts Limit of 2,000 entries per REST API call 
+    # Deprecated alias for `email_to`. Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts. Limit of 2,000 entries per REST API call. Prefer `email_to` in new integrations. 
     attr_accessor :include_email_tokens
+
+    # Recommended for Sending Emails - Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts. Limit of 2,000 entries per REST API call. Supersedes the deprecated `include_email_tokens` field. 
+    attr_accessor :email_to
 
     # Recommended for Sending SMS - Target specific phone numbers. The phone number should be in the E.164 format. Phone number should be an existing subscriber on OneSignal. Refer our docs to learn how to add phone numbers to OneSignal. Example phone number: +1999999999 Limit of 2,000 entries per REST API call 
     attr_accessor :include_phone_numbers
@@ -325,6 +328,9 @@ module OneSignal
     # BCC recipients that were set on this email notification.
     attr_accessor :email_bcc
 
+    # Channel: Email Sender domain to use for the email message. Overrides the default sender domain configured for the app. Only supported when the email service provider is OneSignal Email. 
+    attr_accessor :email_sender_domain
+
     # Channel: SMS Phone Number used to send SMS. Should be a registered Twilio phone number in E.164 format. 
     attr_accessor :sms_from
 
@@ -417,6 +423,7 @@ module OneSignal
         :'excluded_segments' => :'excluded_segments',
         :'include_subscription_ids' => :'include_subscription_ids',
         :'include_email_tokens' => :'include_email_tokens',
+        :'email_to' => :'email_to',
         :'include_phone_numbers' => :'include_phone_numbers',
         :'include_ios_tokens' => :'include_ios_tokens',
         :'include_wp_wns_uris' => :'include_wp_wns_uris',
@@ -519,6 +526,7 @@ module OneSignal
         :'disable_email_click_tracking' => :'disable_email_click_tracking',
         :'include_unsubscribed' => :'include_unsubscribed',
         :'email_bcc' => :'email_bcc',
+        :'email_sender_domain' => :'email_sender_domain',
         :'sms_from' => :'sms_from',
         :'sms_media_urls' => :'sms_media_urls',
         :'filters' => :'filters',
@@ -556,6 +564,7 @@ module OneSignal
         :'excluded_segments' => :'Array<String>',
         :'include_subscription_ids' => :'Array<String>',
         :'include_email_tokens' => :'Array<String>',
+        :'email_to' => :'Array<String>',
         :'include_phone_numbers' => :'Array<String>',
         :'include_ios_tokens' => :'Array<String>',
         :'include_wp_wns_uris' => :'Array<String>',
@@ -658,6 +667,7 @@ module OneSignal
         :'disable_email_click_tracking' => :'Boolean',
         :'include_unsubscribed' => :'Boolean',
         :'email_bcc' => :'Array<String>',
+        :'email_sender_domain' => :'String',
         :'sms_from' => :'String',
         :'sms_media_urls' => :'Array<String>',
         :'filters' => :'Array<FilterExpression>',
@@ -769,6 +779,7 @@ module OneSignal
         :'email_preheader',
         :'disable_email_click_tracking',
         :'email_bcc',
+        :'email_sender_domain',
         :'sms_from',
         :'sms_media_urls',
         :'filters',
@@ -831,6 +842,12 @@ module OneSignal
       if attributes.key?(:'include_email_tokens')
         if (value = attributes[:'include_email_tokens']).is_a?(Array)
           self.include_email_tokens = value
+        end
+      end
+
+      if attributes.key?(:'email_to')
+        if (value = attributes[:'email_to']).is_a?(Array)
+          self.email_to = value
         end
       end
 
@@ -1264,6 +1281,10 @@ module OneSignal
         end
       end
 
+      if attributes.key?(:'email_sender_domain')
+        self.email_sender_domain = attributes[:'email_sender_domain']
+      end
+
       if attributes.key?(:'sms_from')
         self.sms_from = attributes[:'sms_from']
       end
@@ -1422,6 +1443,7 @@ module OneSignal
           excluded_segments == o.excluded_segments &&
           include_subscription_ids == o.include_subscription_ids &&
           include_email_tokens == o.include_email_tokens &&
+          email_to == o.email_to &&
           include_phone_numbers == o.include_phone_numbers &&
           include_ios_tokens == o.include_ios_tokens &&
           include_wp_wns_uris == o.include_wp_wns_uris &&
@@ -1524,6 +1546,7 @@ module OneSignal
           disable_email_click_tracking == o.disable_email_click_tracking &&
           include_unsubscribed == o.include_unsubscribed &&
           email_bcc == o.email_bcc &&
+          email_sender_domain == o.email_sender_domain &&
           sms_from == o.sms_from &&
           sms_media_urls == o.sms_media_urls &&
           filters == o.filters &&
@@ -1557,7 +1580,7 @@ module OneSignal
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [included_segments, excluded_segments, include_subscription_ids, include_email_tokens, include_phone_numbers, include_ios_tokens, include_wp_wns_uris, include_amazon_reg_ids, include_chrome_reg_ids, include_chrome_web_reg_ids, include_android_reg_ids, include_aliases, target_channel, id, value, name, aggregation, is_ios, is_android, is_huawei, is_any_web, is_chrome_web, is_firefox, is_safari, is_wp_wns, is_adm, is_chrome, app_id, external_id, idempotency_key, contents, headings, subtitle, data, huawei_msg_type, url, web_url, app_url, ios_attachments, template_id, content_available, mutable_content, target_content_identifier, big_picture, huawei_big_picture, adm_big_picture, chrome_big_picture, chrome_web_image, buttons, web_buttons, ios_category, android_channel_id, huawei_channel_id, existing_android_channel_id, huawei_existing_channel_id, android_background_layout, small_icon, huawei_small_icon, large_icon, huawei_large_icon, adm_small_icon, adm_large_icon, chrome_web_icon, chrome_web_badge, firefox_icon, chrome_icon, ios_sound, android_sound, huawei_sound, adm_sound, wp_wns_sound, android_led_color, huawei_led_color, android_accent_color, huawei_accent_color, android_visibility, huawei_visibility, ios_badge_type, ios_badge_count, collapse_id, web_push_topic, apns_alert, delayed_option, delivery_time_of_day, ttl, priority, apns_push_type_override, throttle_rate_per_minute, android_group, android_group_message, adm_group, adm_group_message, thread_id, summary_arg, summary_arg_count, ios_relevance_score, ios_interruption_level, email_subject, email_body, email_from_name, email_from_address, email_reply_to_address, email_preheader, disable_email_click_tracking, include_unsubscribed, email_bcc, sms_from, sms_media_urls, filters, custom_data, huawei_badge_class, huawei_badge_add_num, huawei_badge_set_num, huawei_category, huawei_bi_tag, successful, failed, errored, converted, received, outcomes, remaining, queued_at, send_after, completed_at, platform_delivery_stats, canceled, bcc_sent].hash
+      [included_segments, excluded_segments, include_subscription_ids, include_email_tokens, email_to, include_phone_numbers, include_ios_tokens, include_wp_wns_uris, include_amazon_reg_ids, include_chrome_reg_ids, include_chrome_web_reg_ids, include_android_reg_ids, include_aliases, target_channel, id, value, name, aggregation, is_ios, is_android, is_huawei, is_any_web, is_chrome_web, is_firefox, is_safari, is_wp_wns, is_adm, is_chrome, app_id, external_id, idempotency_key, contents, headings, subtitle, data, huawei_msg_type, url, web_url, app_url, ios_attachments, template_id, content_available, mutable_content, target_content_identifier, big_picture, huawei_big_picture, adm_big_picture, chrome_big_picture, chrome_web_image, buttons, web_buttons, ios_category, android_channel_id, huawei_channel_id, existing_android_channel_id, huawei_existing_channel_id, android_background_layout, small_icon, huawei_small_icon, large_icon, huawei_large_icon, adm_small_icon, adm_large_icon, chrome_web_icon, chrome_web_badge, firefox_icon, chrome_icon, ios_sound, android_sound, huawei_sound, adm_sound, wp_wns_sound, android_led_color, huawei_led_color, android_accent_color, huawei_accent_color, android_visibility, huawei_visibility, ios_badge_type, ios_badge_count, collapse_id, web_push_topic, apns_alert, delayed_option, delivery_time_of_day, ttl, priority, apns_push_type_override, throttle_rate_per_minute, android_group, android_group_message, adm_group, adm_group_message, thread_id, summary_arg, summary_arg_count, ios_relevance_score, ios_interruption_level, email_subject, email_body, email_from_name, email_from_address, email_reply_to_address, email_preheader, disable_email_click_tracking, include_unsubscribed, email_bcc, email_sender_domain, sms_from, sms_media_urls, filters, custom_data, huawei_badge_class, huawei_badge_add_num, huawei_badge_set_num, huawei_category, huawei_bi_tag, successful, failed, errored, converted, received, outcomes, remaining, queued_at, send_after, completed_at, platform_delivery_stats, canceled, bcc_sent].hash
     end
 
     # Builds the object from hash

--- a/lib/onesignal/models/subscription_notification_target.rb
+++ b/lib/onesignal/models/subscription_notification_target.rb
@@ -18,8 +18,11 @@ module OneSignal
     # Specific subscription ids to send your notification to. _Does not require API Auth Key._ Not compatible with any other targeting parameters. Example: [\"1dd608f2-c6a1-11e3-851d-000c2940e62c\"] Limit of 2,000 entries per REST API call 
     attr_accessor :include_subscription_ids
 
-    # Recommended for Sending Emails - Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts Limit of 2,000 entries per REST API call 
+    # Deprecated alias for `email_to`. Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts. Limit of 2,000 entries per REST API call. Prefer `email_to` in new integrations. 
     attr_accessor :include_email_tokens
+
+    # Recommended for Sending Emails - Target specific email addresses. If an email does not correspond to an existing user, a new user will be created. Example: nick@catfac.ts. Limit of 2,000 entries per REST API call. Supersedes the deprecated `include_email_tokens` field. 
+    attr_accessor :email_to
 
     # Recommended for Sending SMS - Target specific phone numbers. The phone number should be in the E.164 format. Phone number should be an existing subscriber on OneSignal. Refer our docs to learn how to add phone numbers to OneSignal. Example phone number: +1999999999 Limit of 2,000 entries per REST API call 
     attr_accessor :include_phone_numbers
@@ -74,6 +77,7 @@ module OneSignal
       {
         :'include_subscription_ids' => :'include_subscription_ids',
         :'include_email_tokens' => :'include_email_tokens',
+        :'email_to' => :'email_to',
         :'include_phone_numbers' => :'include_phone_numbers',
         :'include_ios_tokens' => :'include_ios_tokens',
         :'include_wp_wns_uris' => :'include_wp_wns_uris',
@@ -96,6 +100,7 @@ module OneSignal
       {
         :'include_subscription_ids' => :'Array<String>',
         :'include_email_tokens' => :'Array<String>',
+        :'email_to' => :'Array<String>',
         :'include_phone_numbers' => :'Array<String>',
         :'include_ios_tokens' => :'Array<String>',
         :'include_wp_wns_uris' => :'Array<String>',
@@ -140,6 +145,12 @@ module OneSignal
       if attributes.key?(:'include_email_tokens')
         if (value = attributes[:'include_email_tokens']).is_a?(Array)
           self.include_email_tokens = value
+        end
+      end
+
+      if attributes.key?(:'email_to')
+        if (value = attributes[:'email_to']).is_a?(Array)
+          self.email_to = value
         end
       end
 
@@ -228,6 +239,7 @@ module OneSignal
       self.class == o.class &&
           include_subscription_ids == o.include_subscription_ids &&
           include_email_tokens == o.include_email_tokens &&
+          email_to == o.email_to &&
           include_phone_numbers == o.include_phone_numbers &&
           include_ios_tokens == o.include_ios_tokens &&
           include_wp_wns_uris == o.include_wp_wns_uris &&
@@ -248,7 +260,7 @@ module OneSignal
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [include_subscription_ids, include_email_tokens, include_phone_numbers, include_ios_tokens, include_wp_wns_uris, include_amazon_reg_ids, include_chrome_reg_ids, include_chrome_web_reg_ids, include_android_reg_ids, include_aliases, target_channel].hash
+      [include_subscription_ids, include_email_tokens, email_to, include_phone_numbers, include_ios_tokens, include_wp_wns_uris, include_amazon_reg_ids, include_chrome_reg_ids, include_chrome_web_reg_ids, include_android_reg_ids, include_aliases, target_channel].hash
     end
 
     # Builds the object from hash

--- a/spec/models/basic_notification_all_of_spec.rb
+++ b/spec/models/basic_notification_all_of_spec.rb
@@ -587,6 +587,12 @@ describe OneSignal::BasicNotificationAllOf do
     end
   end
 
+  describe 'test attribute "email_sender_domain"' do
+    it 'should work' do
+      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
+    end
+  end
+
   describe 'test attribute "sms_from"' do
     it 'should work' do
       # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers

--- a/spec/models/basic_notification_spec.rb
+++ b/spec/models/basic_notification_spec.rb
@@ -49,6 +49,12 @@ describe OneSignal::BasicNotification do
     end
   end
 
+  describe 'test attribute "email_to"' do
+    it 'should work' do
+      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
+    end
+  end
+
   describe 'test attribute "include_phone_numbers"' do
     it 'should work' do
       # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
@@ -664,6 +670,12 @@ describe OneSignal::BasicNotification do
   end
 
   describe 'test attribute "email_bcc"' do
+    it 'should work' do
+      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
+    end
+  end
+
+  describe 'test attribute "email_sender_domain"' do
     it 'should work' do
       # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
     end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -49,6 +49,12 @@ describe OneSignal::Notification do
     end
   end
 
+  describe 'test attribute "email_to"' do
+    it 'should work' do
+      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
+    end
+  end
+
   describe 'test attribute "include_phone_numbers"' do
     it 'should work' do
       # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
@@ -664,6 +670,12 @@ describe OneSignal::Notification do
   end
 
   describe 'test attribute "email_bcc"' do
+    it 'should work' do
+      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
+    end
+  end
+
+  describe 'test attribute "email_sender_domain"' do
     it 'should work' do
       # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
     end

--- a/spec/models/notification_target_spec.rb
+++ b/spec/models/notification_target_spec.rb
@@ -49,6 +49,12 @@ describe OneSignal::NotificationTarget do
     end
   end
 
+  describe 'test attribute "email_to"' do
+    it 'should work' do
+      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
+    end
+  end
+
   describe 'test attribute "include_phone_numbers"' do
     it 'should work' do
       # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers

--- a/spec/models/notification_with_meta_spec.rb
+++ b/spec/models/notification_with_meta_spec.rb
@@ -49,6 +49,12 @@ describe OneSignal::NotificationWithMeta do
     end
   end
 
+  describe 'test attribute "email_to"' do
+    it 'should work' do
+      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
+    end
+  end
+
   describe 'test attribute "include_phone_numbers"' do
     it 'should work' do
       # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
@@ -664,6 +670,12 @@ describe OneSignal::NotificationWithMeta do
   end
 
   describe 'test attribute "email_bcc"' do
+    it 'should work' do
+      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
+    end
+  end
+
+  describe 'test attribute "email_sender_domain"' do
     it 'should work' do
       # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
     end

--- a/spec/models/subscription_notification_target_spec.rb
+++ b/spec/models/subscription_notification_target_spec.rb
@@ -37,6 +37,12 @@ describe OneSignal::SubscriptionNotificationTarget do
     end
   end
 
+  describe 'test attribute "email_to"' do
+    it 'should work' do
+      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
+    end
+  end
+
   describe 'test attribute "include_phone_numbers"' do
     it 'should work' do
       # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers


### PR DESCRIPTION
## Release v5.5.0

### 🚀 Features
- feat: deprecate `include_email_tokens` in favor of `email_to`; add `email_sender_domain`

---
_Generated from [OneSignal/api-client-libraries@5306c76...b695464](https://github.com/OneSignal/api-client-libraries/compare/5306c7671b1f6194f9800bcf976df0accae3ae8e...b695464f2c408308b9f7c8beb8cd7c0147dd565f)._