### PR TITLE
feat: add v5.7.0 package updates

### DIFF
--- a/docs/CreateNotificationSuccessResponse.md
+++ b/docs/CreateNotificationSuccessResponse.md
@@ -4,7 +4,7 @@
 
 | Name | Type | Description | Notes |
 | ---- | ---- | ----------- | ----- |
-| **id** | **String** | Notification identifier when the request created a notification. An empty string means no notification was created; read &#x60;errors&#x60; for details (HTTP may still be 200). | [optional] |
+| **id** | **String** | Notification identifier when the request created a notification. An empty string means no notification was created; read &#x60;errors&#x60; for details (HTTP may still be 200). All OneSignal server SDKs expose message-sent / message-not-sent narrowing helpers (named idiomatically per language — e.g. &#x60;isMessageSent&#x60;, &#x60;is_message_sent&#x60;, &#x60;message_sent?&#x60;); prefer them over comparing &#x60;id&#x60; directly. | [optional] |
 | **external_id** | **String** | Optional correlation / idempotency-related value from the API response. This is not the end-user External ID used for targeting recipients (that lives under &#x60;include_aliases.external_id&#x60;). | [optional] |
 | **errors** | **Object** | Polymorphic field: may be an array of human-readable strings and/or an object (for example with &#x60;invalid_aliases&#x60;, &#x60;invalid_external_user_ids&#x60;, or &#x60;invalid_player_ids&#x60;) depending on the API response; HTTP may still be 200 with partial success. Typed SDKs model this loosely so both shapes deserialize. | [optional] |
 

--- a/docs/DefaultApi.md
+++ b/docs/DefaultApi.md
@@ -2214,7 +2214,8 @@ app_id = '00000000-0000-0000-0000-000000000000' # String | The app ID that you w
 opts = {
   limit: 10, # Integer | How many notifications to return.  Max is 50.  Default is 50.
   offset: 0, # Integer | Page offset.  Default is 0.  Results are sorted by queued_at in descending order.  queued_at is a representation of the time that the notification was queued at.
-  kind: 0 # Integer | Kind of notifications returned:   * unset - All notification types (default)   * `0` - Dashboard only   * `1` - API only   * `3` - Automated only 
+  kind: 0, # Integer | Kind of notifications returned:   * unset - All notification types (default)   * `0` - Dashboard only   * `1` - API only   * `3` - Automated only 
+  time_offset: '2025-01-01T00:00:00.000Z' # String | Time-offset pagination cursor for sequential pulls of all messages.  Accepts either an ISO 8601 formatted timestamp (e.g. `2025-01-01T00:00:00.000Z`) or the opaque Base64 cursor token returned as `next_time_offset` in a prior response.  When set, results are sorted ascending by send_after and the standard `offset` parameter cannot be used.  Repeat the request with each `next_time_offset` until an empty notifications array is returned.
 }
 
 begin
@@ -2259,6 +2260,7 @@ end
 | **limit** | **Integer** | How many notifications to return.  Max is 50.  Default is 50. | [optional] |
 | **offset** | **Integer** | Page offset.  Default is 0.  Results are sorted by queued_at in descending order.  queued_at is a representation of the time that the notification was queued at. | [optional] |
 | **kind** | **Integer** | Kind of notifications returned:   * unset - All notification types (default)   * &#x60;0&#x60; - Dashboard only   * &#x60;1&#x60; - API only   * &#x60;3&#x60; - Automated only  | [optional] |
+| **time_offset** | **String** | Time-offset pagination cursor for sequential pulls of all messages.  Accepts either an ISO 8601 formatted timestamp (e.g. &#x60;2025-01-01T00:00:00.000Z&#x60;) or the opaque Base64 cursor token returned as &#x60;next_time_offset&#x60; in a prior response.  When set, results are sorted ascending by send_after and the standard &#x60;offset&#x60; parameter cannot be used.  Repeat the request with each &#x60;next_time_offset&#x60; until an empty notifications array is returned. | [optional] |
 
 ### Return type
 

--- a/docs/NotificationSlice.md
+++ b/docs/NotificationSlice.md
@@ -7,6 +7,8 @@
 | **total_count** | **Integer** |  | [optional] |
 | **offset** | **Integer** |  | [optional] |
 | **limit** | **Integer** |  | [optional] |
+| **time_offset** | **String** | The time_offset cursor specified in the request, if any. | [optional] |
+| **next_time_offset** | **String** | An opaque Base64 cursor token representing the next page of messages to fetch.  Present when time_offset was provided in the request.  Pass this value as time_offset on the next request to continue paginating. | [optional] |
 | **notifications** | [**Array&lt;NotificationWithMeta&gt;**](NotificationWithMeta.md) |  | [optional] |
 
 ## Example
@@ -18,6 +20,8 @@ instance = OneSignal::NotificationSlice.new(
   total_count: null,
   offset: null,
   limit: null,
+  time_offset: null,
+  next_time_offset: null,
   notifications: null
 )
 ```

--- a/lib/onesignal/api/default_api.rb
+++ b/lib/onesignal/api/default_api.rb
@@ -1888,6 +1888,7 @@ module OneSignal
     # @option opts [Integer] :limit How many notifications to return.  Max is 50.  Default is 50.
     # @option opts [Integer] :offset Page offset.  Default is 0.  Results are sorted by queued_at in descending order.  queued_at is a representation of the time that the notification was queued at.
     # @option opts [Integer] :kind Kind of notifications returned:   * unset - All notification types (default)   * &#x60;0&#x60; - Dashboard only   * &#x60;1&#x60; - API only   * &#x60;3&#x60; - Automated only 
+    # @option opts [String] :time_offset Time-offset pagination cursor for sequential pulls of all messages.  Accepts either an ISO 8601 formatted timestamp (e.g. &#x60;2025-01-01T00:00:00.000Z&#x60;) or the opaque Base64 cursor token returned as &#x60;next_time_offset&#x60; in a prior response.  When set, results are sorted ascending by send_after and the standard &#x60;offset&#x60; parameter cannot be used.  Repeat the request with each &#x60;next_time_offset&#x60; until an empty notifications array is returned.
     # @return [NotificationSlice]
     def get_notifications(app_id, opts = {})
       data, _status_code, _headers = get_notifications_with_http_info(app_id, opts)
@@ -1901,6 +1902,7 @@ module OneSignal
     # @option opts [Integer] :limit How many notifications to return.  Max is 50.  Default is 50.
     # @option opts [Integer] :offset Page offset.  Default is 0.  Results are sorted by queued_at in descending order.  queued_at is a representation of the time that the notification was queued at.
     # @option opts [Integer] :kind Kind of notifications returned:   * unset - All notification types (default)   * &#x60;0&#x60; - Dashboard only   * &#x60;1&#x60; - API only   * &#x60;3&#x60; - Automated only 
+    # @option opts [String] :time_offset Time-offset pagination cursor for sequential pulls of all messages.  Accepts either an ISO 8601 formatted timestamp (e.g. &#x60;2025-01-01T00:00:00.000Z&#x60;) or the opaque Base64 cursor token returned as &#x60;next_time_offset&#x60; in a prior response.  When set, results are sorted ascending by send_after and the standard &#x60;offset&#x60; parameter cannot be used.  Repeat the request with each &#x60;next_time_offset&#x60; until an empty notifications array is returned.
     # @return [Array<(NotificationSlice, Integer, Hash)>] NotificationSlice data, response status code and response headers
     def get_notifications_with_http_info(app_id, opts = {})
       if @api_client.config.debugging
@@ -1923,6 +1925,7 @@ module OneSignal
       query_params[:'limit'] = opts[:'limit'] if !opts[:'limit'].nil?
       query_params[:'offset'] = opts[:'offset'] if !opts[:'offset'].nil?
       query_params[:'kind'] = opts[:'kind'] if !opts[:'kind'].nil?
+      query_params[:'time_offset'] = opts[:'time_offset'] if !opts[:'time_offset'].nil?
 
       # header parameters
       header_params = opts[:header_params] || {}

--- a/lib/onesignal/helpers.rb
+++ b/lib/onesignal/helpers.rb
@@ -54,6 +54,30 @@ module OneSignal
       end
     end
 
+    # Whether a POST /notifications 200 response is the "message sent" branch.
+    #
+    # POST /notifications returns 200 in two cases that share the
+    # CreateNotificationSuccessResponse shape: a notification was created
+    # (non-empty +id+), or none was (empty +id+, with +errors+ carrying the
+    # reason). Prefer this guard over inspecting +id+ directly.
+    #
+    # @param response [CreateNotificationSuccessResponse]
+    # @return [Boolean] true when a notification was created
+    def self.message_sent?(response)
+      id = response.respond_to?(:id) ? response.id : nil
+      id.is_a?(String) && !id.empty?
+    end
+
+    # Whether a POST /notifications 200 response is the "message not sent"
+    # branch -- no notification was created (+id+ absent or empty); inspect
+    # +errors+ for why.
+    #
+    # @param response [CreateNotificationSuccessResponse]
+    # @return [Boolean] true when no notification was created
+    def self.message_not_sent?(response)
+      !message_sent?(response)
+    end
+
     def self.header_value(headers, name)
       return nil unless headers.respond_to?(:each_pair)
 

--- a/lib/onesignal/models/create_notification_success_response.rb
+++ b/lib/onesignal/models/create_notification_success_response.rb
@@ -15,7 +15,7 @@ require 'time'
 
 module OneSignal
   class CreateNotificationSuccessResponse
-    # Notification identifier when the request created a notification. An empty string means no notification was created; read `errors` for details (HTTP may still be 200).
+    # Notification identifier when the request created a notification. An empty string means no notification was created; read `errors` for details (HTTP may still be 200). All OneSignal server SDKs expose message-sent / message-not-sent narrowing helpers (named idiomatically per language — e.g. `isMessageSent`, `is_message_sent`, `message_sent?`); prefer them over comparing `id` directly.
     attr_accessor :id
 
     # Optional correlation / idempotency-related value from the API response. This is not the end-user External ID used for targeting recipients (that lives under `include_aliases.external_id`).

--- a/lib/onesignal/models/notification_slice.rb
+++ b/lib/onesignal/models/notification_slice.rb
@@ -21,6 +21,12 @@ module OneSignal
 
     attr_accessor :limit
 
+    # The time_offset cursor specified in the request, if any.
+    attr_accessor :time_offset
+
+    # An opaque Base64 cursor token representing the next page of messages to fetch.  Present when time_offset was provided in the request.  Pass this value as time_offset on the next request to continue paginating.
+    attr_accessor :next_time_offset
+
     attr_accessor :notifications
 
     # Attribute mapping from ruby-style variable name to JSON key.
@@ -29,6 +35,8 @@ module OneSignal
         :'total_count' => :'total_count',
         :'offset' => :'offset',
         :'limit' => :'limit',
+        :'time_offset' => :'time_offset',
+        :'next_time_offset' => :'next_time_offset',
         :'notifications' => :'notifications'
       }
     end
@@ -44,6 +52,8 @@ module OneSignal
         :'total_count' => :'Integer',
         :'offset' => :'Integer',
         :'limit' => :'Integer',
+        :'time_offset' => :'String',
+        :'next_time_offset' => :'String',
         :'notifications' => :'Array<NotificationWithMeta>'
       }
     end
@@ -81,6 +91,14 @@ module OneSignal
         self.limit = attributes[:'limit']
       end
 
+      if attributes.key?(:'time_offset')
+        self.time_offset = attributes[:'time_offset']
+      end
+
+      if attributes.key?(:'next_time_offset')
+        self.next_time_offset = attributes[:'next_time_offset']
+      end
+
       if attributes.key?(:'notifications')
         if (value = attributes[:'notifications']).is_a?(Array)
           self.notifications = value
@@ -109,6 +127,8 @@ module OneSignal
           total_count == o.total_count &&
           offset == o.offset &&
           limit == o.limit &&
+          time_offset == o.time_offset &&
+          next_time_offset == o.next_time_offset &&
           notifications == o.notifications
     end
 
@@ -121,7 +141,7 @@ module OneSignal
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [total_count, offset, limit, notifications].hash
+      [total_count, offset, limit, time_offset, next_time_offset, notifications].hash
     end
 
     # Builds the object from hash

--- a/spec/api/default_api_spec.rb
+++ b/spec/api/default_api_spec.rb
@@ -373,6 +373,7 @@ describe 'DefaultApi' do
   # @option opts [Integer] :limit How many notifications to return.  Max is 50.  Default is 50.
   # @option opts [Integer] :offset Page offset.  Default is 0.  Results are sorted by queued_at in descending order.  queued_at is a representation of the time that the notification was queued at.
   # @option opts [Integer] :kind Kind of notifications returned:   * unset - All notification types (default)   * &#x60;0&#x60; - Dashboard only   * &#x60;1&#x60; - API only   * &#x60;3&#x60; - Automated only 
+  # @option opts [String] :time_offset Time-offset pagination cursor for sequential pulls of all messages.  Accepts either an ISO 8601 formatted timestamp (e.g. &#x60;2025-01-01T00:00:00.000Z&#x60;) or the opaque Base64 cursor token returned as &#x60;next_time_offset&#x60; in a prior response.  When set, results are sorted ascending by send_after and the standard &#x60;offset&#x60; parameter cannot be used.  Repeat the request with each &#x60;next_time_offset&#x60; until an empty notifications array is returned.
   # @return [NotificationSlice]
   describe 'get_notifications test' do
     it 'should work' do

--- a/spec/models/notification_slice_spec.rb
+++ b/spec/models/notification_slice_spec.rb
@@ -43,6 +43,18 @@ describe OneSignal::NotificationSlice do
     end
   end
 
+  describe 'test attribute "time_offset"' do
+    it 'should work' do
+      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
+    end
+  end
+
+  describe 'test attribute "next_time_offset"' do
+    it 'should work' do
+      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
+    end
+  end
+
   describe 'test attribute "notifications"' do
     it 'should work' do
       # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers


### PR DESCRIPTION
## Release v5.7.0

### 🚀 Features
- feat: [SDK-4440] generate typed error-code catalog module per SDK
- feat: [SDK-4441] add idempotency-key retry helper for create-notification
- feat: [SDK-4441] expose createNotificationWithRetry as a client method
- feat: [SDK-4441] clamp retry helper backoff base to [1s, 60s]
- feat: [SDK-4776] expose time_offset pagination on get_notifications
- feat: [SDK-4781] add message-sent/not-sent narrowing helpers
- feat: [SDK-4781] refine narrowing-helper doc nudge and PHP null-safety

### 🐛 Bug Fixes
- fix: [SDK-4440] reclassify OVER_SUBSCRIBER_LIMIT as a template entry
- fix: [SDK-4438] treat empty title as missing in all error-messages accessors
- fix: [SDK-4438] surface object-shaped errors in error-messages accessors
- fix: [SDK-4440] trim OneSignalErrors catalog to a verified minimal set
- fix: [SDK-4776] append time_offset after kind in get_notifications

### 📚 Docs
- docs: [SDK-4441] add createNotificationWithRetry example to DefaultApi docs
- docs: [SDK-4440] fix OneSignalErrors usage example for the 200-status sentinel
- docs: clarify errorMessages excludes structured meta; show how to read it
- docs: demonstrate reading 409 conflict meta in CreateUser example
- docs: [SDK-4440] cross-link OneSignalErrors catalog from DefaultApi.md error handling

---
_Generated from [OneSignal/api-client-libraries@e4fc576...2907ac8](https://github.com/OneSignal/api-client-libraries/compare/e4fc576245a3346beb6b5edb89ad0ccb03dfa655...2907ac87ca594fc5aee71ccfab5839f35b6a0f38)._