### PR TITLE
fix: add v5.11.0 package updates

### DIFF
--- a/docs/BasicNotification.md
+++ b/docs/BasicNotification.md
@@ -49,6 +49,7 @@
 | **mutable_content** | **Boolean** | Channel: Push Notifications Platform: iOS 10+ Always defaults to true and cannot be turned off. Allows tracking of notification receives and changing of the notification content in your app before it is displayed. Triggers didReceive(_:withContentHandler:) on your UNNotificationServiceExtension.  | [optional] |
 | **target_content_identifier** | **String** | Channel: Push Notifications Platform: iOS 13+ Use to target a specific experience in your App Clip, or to target your notification to a specific window in a multi-scene App.  | [optional] |
 | **big_picture** | **String** | Channel: Push Notifications Platform: Android Picture to display in the expanded view. Can be a drawable resource name or a URL.  | [optional] |
+| **global_image** | **String** | Channel: Push Notifications Platform: All Picture to display on all platforms that support it. Must be a URL to an image file. Platform-specific picture fields (big_picture, huawei_big_picture, adm_big_picture, chrome_web_image, ios_attachments, firefox_icon) take precedence over this value when set.  | [optional] |
 | **huawei_big_picture** | **String** | Channel: Push Notifications Platform: Huawei Picture to display in the expanded view. Can be a drawable resource name or a URL.  | [optional] |
 | **adm_big_picture** | **String** | Channel: Push Notifications Platform: Amazon Picture to display in the expanded view. Can be a drawable resource name or a URL.  | [optional] |
 | **chrome_big_picture** | **String** | Channel: Push Notifications Platform: ChromeApp Large picture to display below the notification text. Must be a local URL.  | [optional] |
@@ -173,6 +174,7 @@ instance = OneSignal::BasicNotification.new(
   mutable_content: nil,
   target_content_identifier: nil,
   big_picture: nil,
+  global_image: nil,
   huawei_big_picture: nil,
   adm_big_picture: nil,
   chrome_big_picture: nil,

--- a/docs/BasicNotificationAllOf.md
+++ b/docs/BasicNotificationAllOf.md
@@ -35,6 +35,7 @@
 | **mutable_content** | **Boolean** | Channel: Push Notifications Platform: iOS 10+ Always defaults to true and cannot be turned off. Allows tracking of notification receives and changing of the notification content in your app before it is displayed. Triggers didReceive(_:withContentHandler:) on your UNNotificationServiceExtension.  | [optional] |
 | **target_content_identifier** | **String** | Channel: Push Notifications Platform: iOS 13+ Use to target a specific experience in your App Clip, or to target your notification to a specific window in a multi-scene App.  | [optional] |
 | **big_picture** | **String** | Channel: Push Notifications Platform: Android Picture to display in the expanded view. Can be a drawable resource name or a URL.  | [optional] |
+| **global_image** | **String** | Channel: Push Notifications Platform: All Picture to display on all platforms that support it. Must be a URL to an image file. Platform-specific picture fields (big_picture, huawei_big_picture, adm_big_picture, chrome_web_image, ios_attachments, firefox_icon) take precedence over this value when set.  | [optional] |
 | **huawei_big_picture** | **String** | Channel: Push Notifications Platform: Huawei Picture to display in the expanded view. Can be a drawable resource name or a URL.  | [optional] |
 | **adm_big_picture** | **String** | Channel: Push Notifications Platform: Amazon Picture to display in the expanded view. Can be a drawable resource name or a URL.  | [optional] |
 | **chrome_big_picture** | **String** | Channel: Push Notifications Platform: ChromeApp Large picture to display below the notification text. Must be a local URL.  | [optional] |
@@ -145,6 +146,7 @@ instance = OneSignal::BasicNotificationAllOf.new(
   mutable_content: nil,
   target_content_identifier: nil,
   big_picture: nil,
+  global_image: nil,
   huawei_big_picture: nil,
   adm_big_picture: nil,
   chrome_big_picture: nil,

--- a/docs/DefaultApi.md
+++ b/docs/DefaultApi.md
@@ -22,7 +22,7 @@ All URIs are relative to *https://api.onesignal.com*
 | [**delete_subscription**](DefaultApi.md#delete_subscription) | **DELETE** /apps/{app_id}/subscriptions/{subscription_id} |  |
 | [**delete_template**](DefaultApi.md#delete_template) | **DELETE** /templates/{template_id} | Delete template |
 | [**delete_user**](DefaultApi.md#delete_user) | **DELETE** /apps/{app_id}/users/by/{alias_label}/{alias_id} |  |
-| [**export_events**](DefaultApi.md#export_events) | **POST** /notifications/{notification_id}/export_events?app_id&#x3D;{app_id} | Export CSV of Events |
+| [**export_events**](DefaultApi.md#export_events) | **POST** /notifications/{notification_id}/export_events | Export CSV of Events |
 | [**export_subscriptions**](DefaultApi.md#export_subscriptions) | **POST** /players/csv_export?app_id&#x3D;{app_id} | Export CSV of Subscriptions |
 | [**get_aliases**](DefaultApi.md#get_aliases) | **GET** /apps/{app_id}/users/by/{alias_label}/{alias_id}/identity |  |
 | [**get_aliases_by_subscription**](DefaultApi.md#get_aliases_by_subscription) | **GET** /apps/{app_id}/subscriptions/{subscription_id}/user/identity |  |

--- a/docs/Notification.md
+++ b/docs/Notification.md
@@ -49,6 +49,7 @@
 | **mutable_content** | **Boolean** | Channel: Push Notifications Platform: iOS 10+ Always defaults to true and cannot be turned off. Allows tracking of notification receives and changing of the notification content in your app before it is displayed. Triggers didReceive(_:withContentHandler:) on your UNNotificationServiceExtension.  | [optional] |
 | **target_content_identifier** | **String** | Channel: Push Notifications Platform: iOS 13+ Use to target a specific experience in your App Clip, or to target your notification to a specific window in a multi-scene App.  | [optional] |
 | **big_picture** | **String** | Channel: Push Notifications Platform: Android Picture to display in the expanded view. Can be a drawable resource name or a URL.  | [optional] |
+| **global_image** | **String** | Channel: Push Notifications Platform: All Picture to display on all platforms that support it. Must be a URL to an image file. Platform-specific picture fields (big_picture, huawei_big_picture, adm_big_picture, chrome_web_image, ios_attachments, firefox_icon) take precedence over this value when set.  | [optional] |
 | **huawei_big_picture** | **String** | Channel: Push Notifications Platform: Huawei Picture to display in the expanded view. Can be a drawable resource name or a URL.  | [optional] |
 | **adm_big_picture** | **String** | Channel: Push Notifications Platform: Amazon Picture to display in the expanded view. Can be a drawable resource name or a URL.  | [optional] |
 | **chrome_big_picture** | **String** | Channel: Push Notifications Platform: ChromeApp Large picture to display below the notification text. Must be a local URL.  | [optional] |
@@ -174,6 +175,7 @@ instance = OneSignal::Notification.new(
   mutable_content: nil,
   target_content_identifier: nil,
   big_picture: nil,
+  global_image: nil,
   huawei_big_picture: nil,
   adm_big_picture: nil,
   chrome_big_picture: nil,

--- a/docs/NotificationWithMeta.md
+++ b/docs/NotificationWithMeta.md
@@ -49,6 +49,7 @@
 | **mutable_content** | **Boolean** | Channel: Push Notifications Platform: iOS 10+ Always defaults to true and cannot be turned off. Allows tracking of notification receives and changing of the notification content in your app before it is displayed. Triggers didReceive(_:withContentHandler:) on your UNNotificationServiceExtension.  | [optional] |
 | **target_content_identifier** | **String** | Channel: Push Notifications Platform: iOS 13+ Use to target a specific experience in your App Clip, or to target your notification to a specific window in a multi-scene App.  | [optional] |
 | **big_picture** | **String** | Channel: Push Notifications Platform: Android Picture to display in the expanded view. Can be a drawable resource name or a URL.  | [optional] |
+| **global_image** | **String** | Channel: Push Notifications Platform: All Picture to display on all platforms that support it. Must be a URL to an image file. Platform-specific picture fields (big_picture, huawei_big_picture, adm_big_picture, chrome_web_image, ios_attachments, firefox_icon) take precedence over this value when set.  | [optional] |
 | **huawei_big_picture** | **String** | Channel: Push Notifications Platform: Huawei Picture to display in the expanded view. Can be a drawable resource name or a URL.  | [optional] |
 | **adm_big_picture** | **String** | Channel: Push Notifications Platform: Amazon Picture to display in the expanded view. Can be a drawable resource name or a URL.  | [optional] |
 | **chrome_big_picture** | **String** | Channel: Push Notifications Platform: ChromeApp Large picture to display below the notification text. Must be a local URL.  | [optional] |
@@ -186,6 +187,7 @@ instance = OneSignal::NotificationWithMeta.new(
   mutable_content: nil,
   target_content_identifier: nil,
   big_picture: nil,
+  global_image: nil,
   huawei_big_picture: nil,
   adm_big_picture: nil,
   chrome_big_picture: nil,

--- a/lib/onesignal/api/default_api.rb
+++ b/lib/onesignal/api/default_api.rb
@@ -1367,7 +1367,7 @@ module OneSignal
         fail ArgumentError, "Missing the required parameter 'app_id' when calling DefaultApi.export_events"
       end
       # resource path
-      local_var_path = '/notifications/{notification_id}/export_events?app_id={app_id}'.sub('{' + 'notification_id' + '}', CGI.escape(notification_id.to_s))
+      local_var_path = '/notifications/{notification_id}/export_events'.sub('{' + 'notification_id' + '}', CGI.escape(notification_id.to_s))
 
       # query parameters
       query_params = opts[:query_params] || {}

--- a/lib/onesignal/models/basic_notification.rb
+++ b/lib/onesignal/models/basic_notification.rb
@@ -143,6 +143,9 @@ module OneSignal
     # Channel: Push Notifications Platform: Android Picture to display in the expanded view. Can be a drawable resource name or a URL. 
     attr_accessor :big_picture
 
+    # Channel: Push Notifications Platform: All Picture to display on all platforms that support it. Must be a URL to an image file. Platform-specific picture fields (big_picture, huawei_big_picture, adm_big_picture, chrome_web_image, ios_attachments, firefox_icon) take precedence over this value when set. 
+    attr_accessor :global_image
+
     # Channel: Push Notifications Platform: Huawei Picture to display in the expanded view. Can be a drawable resource name or a URL. 
     attr_accessor :huawei_big_picture
 
@@ -427,6 +430,7 @@ module OneSignal
         :'mutable_content' => :'mutable_content',
         :'target_content_identifier' => :'target_content_identifier',
         :'big_picture' => :'big_picture',
+        :'global_image' => :'global_image',
         :'huawei_big_picture' => :'huawei_big_picture',
         :'adm_big_picture' => :'adm_big_picture',
         :'chrome_big_picture' => :'chrome_big_picture',
@@ -555,6 +559,7 @@ module OneSignal
         :'mutable_content' => :'Boolean',
         :'target_content_identifier' => :'String',
         :'big_picture' => :'String',
+        :'global_image' => :'String',
         :'huawei_big_picture' => :'String',
         :'adm_big_picture' => :'String',
         :'chrome_big_picture' => :'String',
@@ -661,6 +666,7 @@ module OneSignal
         :'content_available',
         :'target_content_identifier',
         :'big_picture',
+        :'global_image',
         :'huawei_big_picture',
         :'adm_big_picture',
         :'chrome_big_picture',
@@ -957,6 +963,10 @@ module OneSignal
 
       if attributes.key?(:'big_picture')
         self.big_picture = attributes[:'big_picture']
+      end
+
+      if attributes.key?(:'global_image')
+        self.global_image = attributes[:'global_image']
       end
 
       if attributes.key?(:'huawei_big_picture')
@@ -1377,6 +1387,7 @@ module OneSignal
           mutable_content == o.mutable_content &&
           target_content_identifier == o.target_content_identifier &&
           big_picture == o.big_picture &&
+          global_image == o.global_image &&
           huawei_big_picture == o.huawei_big_picture &&
           adm_big_picture == o.adm_big_picture &&
           chrome_big_picture == o.chrome_big_picture &&
@@ -1460,7 +1471,7 @@ module OneSignal
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [included_segments, excluded_segments, include_subscription_ids, include_email_tokens, email_to, include_phone_numbers, include_ios_tokens, include_wp_wns_uris, include_amazon_reg_ids, include_chrome_reg_ids, include_chrome_web_reg_ids, include_android_reg_ids, include_aliases, target_channel, id, value, name, aggregation, is_ios, is_android, is_huawei, is_any_web, is_chrome_web, is_firefox, is_safari, is_wp_wns, is_adm, is_chrome, app_id, external_id, idempotency_key, contents, headings, subtitle, data, huawei_msg_type, url, web_url, app_url, ios_attachments, template_id, content_available, mutable_content, target_content_identifier, big_picture, huawei_big_picture, adm_big_picture, chrome_big_picture, chrome_web_image, buttons, web_buttons, ios_category, android_channel_id, huawei_channel_id, existing_android_channel_id, huawei_existing_channel_id, android_background_layout, small_icon, huawei_small_icon, large_icon, huawei_large_icon, adm_small_icon, adm_large_icon, chrome_web_icon, chrome_web_badge, firefox_icon, chrome_icon, ios_sound, android_sound, huawei_sound, adm_sound, wp_wns_sound, android_led_color, huawei_led_color, android_accent_color, huawei_accent_color, android_visibility, huawei_visibility, ios_badge_type, ios_badge_count, collapse_id, web_push_topic, apns_alert, delayed_option, delivery_time_of_day, ttl, priority, apns_push_type_override, throttle_rate_per_minute, android_group, android_group_message, adm_group, adm_group_message, thread_id, summary_arg, summary_arg_count, ios_relevance_score, ios_interruption_level, email_subject, email_body, email_from_name, email_from_address, email_reply_to_address, email_preheader, disable_email_click_tracking, include_unsubscribed, email_bcc, email_sender_domain, sms_from, sms_media_urls, filters, custom_data, huawei_badge_class, huawei_badge_add_num, huawei_badge_set_num, huawei_category, huawei_bi_tag].hash
+      [included_segments, excluded_segments, include_subscription_ids, include_email_tokens, email_to, include_phone_numbers, include_ios_tokens, include_wp_wns_uris, include_amazon_reg_ids, include_chrome_reg_ids, include_chrome_web_reg_ids, include_android_reg_ids, include_aliases, target_channel, id, value, name, aggregation, is_ios, is_android, is_huawei, is_any_web, is_chrome_web, is_firefox, is_safari, is_wp_wns, is_adm, is_chrome, app_id, external_id, idempotency_key, contents, headings, subtitle, data, huawei_msg_type, url, web_url, app_url, ios_attachments, template_id, content_available, mutable_content, target_content_identifier, big_picture, global_image, huawei_big_picture, adm_big_picture, chrome_big_picture, chrome_web_image, buttons, web_buttons, ios_category, android_channel_id, huawei_channel_id, existing_android_channel_id, huawei_existing_channel_id, android_background_layout, small_icon, huawei_small_icon, large_icon, huawei_large_icon, adm_small_icon, adm_large_icon, chrome_web_icon, chrome_web_badge, firefox_icon, chrome_icon, ios_sound, android_sound, huawei_sound, adm_sound, wp_wns_sound, android_led_color, huawei_led_color, android_accent_color, huawei_accent_color, android_visibility, huawei_visibility, ios_badge_type, ios_badge_count, collapse_id, web_push_topic, apns_alert, delayed_option, delivery_time_of_day, ttl, priority, apns_push_type_override, throttle_rate_per_minute, android_group, android_group_message, adm_group, adm_group_message, thread_id, summary_arg, summary_arg_count, ios_relevance_score, ios_interruption_level, email_subject, email_body, email_from_name, email_from_address, email_reply_to_address, email_preheader, disable_email_click_tracking, include_unsubscribed, email_bcc, email_sender_domain, sms_from, sms_media_urls, filters, custom_data, huawei_badge_class, huawei_badge_add_num, huawei_badge_set_num, huawei_category, huawei_bi_tag].hash
     end
 
     # Builds the object from hash

--- a/lib/onesignal/models/basic_notification_all_of.rb
+++ b/lib/onesignal/models/basic_notification_all_of.rb
@@ -102,6 +102,9 @@ module OneSignal
     # Channel: Push Notifications Platform: Android Picture to display in the expanded view. Can be a drawable resource name or a URL. 
     attr_accessor :big_picture
 
+    # Channel: Push Notifications Platform: All Picture to display on all platforms that support it. Must be a URL to an image file. Platform-specific picture fields (big_picture, huawei_big_picture, adm_big_picture, chrome_web_image, ios_attachments, firefox_icon) take precedence over this value when set. 
+    attr_accessor :global_image
+
     # Channel: Push Notifications Platform: Huawei Picture to display in the expanded view. Can be a drawable resource name or a URL. 
     attr_accessor :huawei_big_picture
 
@@ -372,6 +375,7 @@ module OneSignal
         :'mutable_content' => :'mutable_content',
         :'target_content_identifier' => :'target_content_identifier',
         :'big_picture' => :'big_picture',
+        :'global_image' => :'global_image',
         :'huawei_big_picture' => :'huawei_big_picture',
         :'adm_big_picture' => :'adm_big_picture',
         :'chrome_big_picture' => :'chrome_big_picture',
@@ -486,6 +490,7 @@ module OneSignal
         :'mutable_content' => :'Boolean',
         :'target_content_identifier' => :'String',
         :'big_picture' => :'String',
+        :'global_image' => :'String',
         :'huawei_big_picture' => :'String',
         :'adm_big_picture' => :'String',
         :'chrome_big_picture' => :'String',
@@ -590,6 +595,7 @@ module OneSignal
         :'content_available',
         :'target_content_identifier',
         :'big_picture',
+        :'global_image',
         :'huawei_big_picture',
         :'adm_big_picture',
         :'chrome_big_picture',
@@ -796,6 +802,10 @@ module OneSignal
 
       if attributes.key?(:'big_picture')
         self.big_picture = attributes[:'big_picture']
+      end
+
+      if attributes.key?(:'global_image')
+        self.global_image = attributes[:'global_image']
       end
 
       if attributes.key?(:'huawei_big_picture')
@@ -1185,6 +1195,7 @@ module OneSignal
           mutable_content == o.mutable_content &&
           target_content_identifier == o.target_content_identifier &&
           big_picture == o.big_picture &&
+          global_image == o.global_image &&
           huawei_big_picture == o.huawei_big_picture &&
           adm_big_picture == o.adm_big_picture &&
           chrome_big_picture == o.chrome_big_picture &&
@@ -1268,7 +1279,7 @@ module OneSignal
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [id, value, name, aggregation, is_ios, is_android, is_huawei, is_any_web, is_chrome_web, is_firefox, is_safari, is_wp_wns, is_adm, is_chrome, app_id, external_id, idempotency_key, contents, headings, subtitle, data, huawei_msg_type, url, web_url, app_url, ios_attachments, template_id, content_available, mutable_content, target_content_identifier, big_picture, huawei_big_picture, adm_big_picture, chrome_big_picture, chrome_web_image, buttons, web_buttons, ios_category, android_channel_id, huawei_channel_id, existing_android_channel_id, huawei_existing_channel_id, android_background_layout, small_icon, huawei_small_icon, large_icon, huawei_large_icon, adm_small_icon, adm_large_icon, chrome_web_icon, chrome_web_badge, firefox_icon, chrome_icon, ios_sound, android_sound, huawei_sound, adm_sound, wp_wns_sound, android_led_color, huawei_led_color, android_accent_color, huawei_accent_color, android_visibility, huawei_visibility, ios_badge_type, ios_badge_count, collapse_id, web_push_topic, apns_alert, delayed_option, delivery_time_of_day, ttl, priority, apns_push_type_override, throttle_rate_per_minute, android_group, android_group_message, adm_group, adm_group_message, thread_id, summary_arg, summary_arg_count, ios_relevance_score, ios_interruption_level, email_subject, email_body, email_from_name, email_from_address, email_reply_to_address, email_preheader, disable_email_click_tracking, include_unsubscribed, email_bcc, email_sender_domain, sms_from, sms_media_urls, filters, custom_data, huawei_badge_class, huawei_badge_add_num, huawei_badge_set_num, huawei_category, huawei_bi_tag].hash
+      [id, value, name, aggregation, is_ios, is_android, is_huawei, is_any_web, is_chrome_web, is_firefox, is_safari, is_wp_wns, is_adm, is_chrome, app_id, external_id, idempotency_key, contents, headings, subtitle, data, huawei_msg_type, url, web_url, app_url, ios_attachments, template_id, content_available, mutable_content, target_content_identifier, big_picture, global_image, huawei_big_picture, adm_big_picture, chrome_big_picture, chrome_web_image, buttons, web_buttons, ios_category, android_channel_id, huawei_channel_id, existing_android_channel_id, huawei_existing_channel_id, android_background_layout, small_icon, huawei_small_icon, large_icon, huawei_large_icon, adm_small_icon, adm_large_icon, chrome_web_icon, chrome_web_badge, firefox_icon, chrome_icon, ios_sound, android_sound, huawei_sound, adm_sound, wp_wns_sound, android_led_color, huawei_led_color, android_accent_color, huawei_accent_color, android_visibility, huawei_visibility, ios_badge_type, ios_badge_count, collapse_id, web_push_topic, apns_alert, delayed_option, delivery_time_of_day, ttl, priority, apns_push_type_override, throttle_rate_per_minute, android_group, android_group_message, adm_group, adm_group_message, thread_id, summary_arg, summary_arg_count, ios_relevance_score, ios_interruption_level, email_subject, email_body, email_from_name, email_from_address, email_reply_to_address, email_preheader, disable_email_click_tracking, include_unsubscribed, email_bcc, email_sender_domain, sms_from, sms_media_urls, filters, custom_data, huawei_badge_class, huawei_badge_add_num, huawei_badge_set_num, huawei_category, huawei_bi_tag].hash
     end
 
     # Builds the object from hash

--- a/lib/onesignal/models/notification.rb
+++ b/lib/onesignal/models/notification.rb
@@ -143,6 +143,9 @@ module OneSignal
     # Channel: Push Notifications Platform: Android Picture to display in the expanded view. Can be a drawable resource name or a URL. 
     attr_accessor :big_picture
 
+    # Channel: Push Notifications Platform: All Picture to display on all platforms that support it. Must be a URL to an image file. Platform-specific picture fields (big_picture, huawei_big_picture, adm_big_picture, chrome_web_image, ios_attachments, firefox_icon) take precedence over this value when set. 
+    attr_accessor :global_image
+
     # Channel: Push Notifications Platform: Huawei Picture to display in the expanded view. Can be a drawable resource name or a URL. 
     attr_accessor :huawei_big_picture
 
@@ -430,6 +433,7 @@ module OneSignal
         :'mutable_content' => :'mutable_content',
         :'target_content_identifier' => :'target_content_identifier',
         :'big_picture' => :'big_picture',
+        :'global_image' => :'global_image',
         :'huawei_big_picture' => :'huawei_big_picture',
         :'adm_big_picture' => :'adm_big_picture',
         :'chrome_big_picture' => :'chrome_big_picture',
@@ -559,6 +563,7 @@ module OneSignal
         :'mutable_content' => :'Boolean',
         :'target_content_identifier' => :'String',
         :'big_picture' => :'String',
+        :'global_image' => :'String',
         :'huawei_big_picture' => :'String',
         :'adm_big_picture' => :'String',
         :'chrome_big_picture' => :'String',
@@ -666,6 +671,7 @@ module OneSignal
         :'content_available',
         :'target_content_identifier',
         :'big_picture',
+        :'global_image',
         :'huawei_big_picture',
         :'adm_big_picture',
         :'chrome_big_picture',
@@ -963,6 +969,10 @@ module OneSignal
 
       if attributes.key?(:'big_picture')
         self.big_picture = attributes[:'big_picture']
+      end
+
+      if attributes.key?(:'global_image')
+        self.global_image = attributes[:'global_image']
       end
 
       if attributes.key?(:'huawei_big_picture')
@@ -1387,6 +1397,7 @@ module OneSignal
           mutable_content == o.mutable_content &&
           target_content_identifier == o.target_content_identifier &&
           big_picture == o.big_picture &&
+          global_image == o.global_image &&
           huawei_big_picture == o.huawei_big_picture &&
           adm_big_picture == o.adm_big_picture &&
           chrome_big_picture == o.chrome_big_picture &&
@@ -1471,7 +1482,7 @@ module OneSignal
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [included_segments, excluded_segments, include_subscription_ids, include_email_tokens, email_to, include_phone_numbers, include_ios_tokens, include_wp_wns_uris, include_amazon_reg_ids, include_chrome_reg_ids, include_chrome_web_reg_ids, include_android_reg_ids, include_aliases, target_channel, id, value, name, aggregation, is_ios, is_android, is_huawei, is_any_web, is_chrome_web, is_firefox, is_safari, is_wp_wns, is_adm, is_chrome, app_id, external_id, idempotency_key, contents, headings, subtitle, data, huawei_msg_type, url, web_url, app_url, ios_attachments, template_id, content_available, mutable_content, target_content_identifier, big_picture, huawei_big_picture, adm_big_picture, chrome_big_picture, chrome_web_image, buttons, web_buttons, ios_category, android_channel_id, huawei_channel_id, existing_android_channel_id, huawei_existing_channel_id, android_background_layout, small_icon, huawei_small_icon, large_icon, huawei_large_icon, adm_small_icon, adm_large_icon, chrome_web_icon, chrome_web_badge, firefox_icon, chrome_icon, ios_sound, android_sound, huawei_sound, adm_sound, wp_wns_sound, android_led_color, huawei_led_color, android_accent_color, huawei_accent_color, android_visibility, huawei_visibility, ios_badge_type, ios_badge_count, collapse_id, web_push_topic, apns_alert, delayed_option, delivery_time_of_day, ttl, priority, apns_push_type_override, throttle_rate_per_minute, android_group, android_group_message, adm_group, adm_group_message, thread_id, summary_arg, summary_arg_count, ios_relevance_score, ios_interruption_level, email_subject, email_body, email_from_name, email_from_address, email_reply_to_address, email_preheader, disable_email_click_tracking, include_unsubscribed, email_bcc, email_sender_domain, sms_from, sms_media_urls, filters, custom_data, huawei_badge_class, huawei_badge_add_num, huawei_badge_set_num, huawei_category, huawei_bi_tag, send_after].hash
+      [included_segments, excluded_segments, include_subscription_ids, include_email_tokens, email_to, include_phone_numbers, include_ios_tokens, include_wp_wns_uris, include_amazon_reg_ids, include_chrome_reg_ids, include_chrome_web_reg_ids, include_android_reg_ids, include_aliases, target_channel, id, value, name, aggregation, is_ios, is_android, is_huawei, is_any_web, is_chrome_web, is_firefox, is_safari, is_wp_wns, is_adm, is_chrome, app_id, external_id, idempotency_key, contents, headings, subtitle, data, huawei_msg_type, url, web_url, app_url, ios_attachments, template_id, content_available, mutable_content, target_content_identifier, big_picture, global_image, huawei_big_picture, adm_big_picture, chrome_big_picture, chrome_web_image, buttons, web_buttons, ios_category, android_channel_id, huawei_channel_id, existing_android_channel_id, huawei_existing_channel_id, android_background_layout, small_icon, huawei_small_icon, large_icon, huawei_large_icon, adm_small_icon, adm_large_icon, chrome_web_icon, chrome_web_badge, firefox_icon, chrome_icon, ios_sound, android_sound, huawei_sound, adm_sound, wp_wns_sound, android_led_color, huawei_led_color, android_accent_color, huawei_accent_color, android_visibility, huawei_visibility, ios_badge_type, ios_badge_count, collapse_id, web_push_topic, apns_alert, delayed_option, delivery_time_of_day, ttl, priority, apns_push_type_override, throttle_rate_per_minute, android_group, android_group_message, adm_group, adm_group_message, thread_id, summary_arg, summary_arg_count, ios_relevance_score, ios_interruption_level, email_subject, email_body, email_from_name, email_from_address, email_reply_to_address, email_preheader, disable_email_click_tracking, include_unsubscribed, email_bcc, email_sender_domain, sms_from, sms_media_urls, filters, custom_data, huawei_badge_class, huawei_badge_add_num, huawei_badge_set_num, huawei_category, huawei_bi_tag, send_after].hash
     end
 
     # Builds the object from hash

--- a/lib/onesignal/models/notification_with_meta.rb
+++ b/lib/onesignal/models/notification_with_meta.rb
@@ -143,6 +143,9 @@ module OneSignal
     # Channel: Push Notifications Platform: Android Picture to display in the expanded view. Can be a drawable resource name or a URL. 
     attr_accessor :big_picture
 
+    # Channel: Push Notifications Platform: All Picture to display on all platforms that support it. Must be a URL to an image file. Platform-specific picture fields (big_picture, huawei_big_picture, adm_big_picture, chrome_web_image, ios_attachments, firefox_icon) take precedence over this value when set. 
+    attr_accessor :global_image
+
     # Channel: Push Notifications Platform: Huawei Picture to display in the expanded view. Can be a drawable resource name or a URL. 
     attr_accessor :huawei_big_picture
 
@@ -464,6 +467,7 @@ module OneSignal
         :'mutable_content' => :'mutable_content',
         :'target_content_identifier' => :'target_content_identifier',
         :'big_picture' => :'big_picture',
+        :'global_image' => :'global_image',
         :'huawei_big_picture' => :'huawei_big_picture',
         :'adm_big_picture' => :'adm_big_picture',
         :'chrome_big_picture' => :'chrome_big_picture',
@@ -605,6 +609,7 @@ module OneSignal
         :'mutable_content' => :'Boolean',
         :'target_content_identifier' => :'String',
         :'big_picture' => :'String',
+        :'global_image' => :'String',
         :'huawei_big_picture' => :'String',
         :'adm_big_picture' => :'String',
         :'chrome_big_picture' => :'String',
@@ -724,6 +729,7 @@ module OneSignal
         :'content_available',
         :'target_content_identifier',
         :'big_picture',
+        :'global_image',
         :'huawei_big_picture',
         :'adm_big_picture',
         :'chrome_big_picture',
@@ -1026,6 +1032,10 @@ module OneSignal
 
       if attributes.key?(:'big_picture')
         self.big_picture = attributes[:'big_picture']
+      end
+
+      if attributes.key?(:'global_image')
+        self.global_image = attributes[:'global_image']
       end
 
       if attributes.key?(:'huawei_big_picture')
@@ -1485,6 +1495,7 @@ module OneSignal
           mutable_content == o.mutable_content &&
           target_content_identifier == o.target_content_identifier &&
           big_picture == o.big_picture &&
+          global_image == o.global_image &&
           huawei_big_picture == o.huawei_big_picture &&
           adm_big_picture == o.adm_big_picture &&
           chrome_big_picture == o.chrome_big_picture &&
@@ -1581,7 +1592,7 @@ module OneSignal
     # Calculates hash code according to all attributes.
     # @return [Integer] Hash code
     def hash
-      [included_segments, excluded_segments, include_subscription_ids, include_email_tokens, email_to, include_phone_numbers, include_ios_tokens, include_wp_wns_uris, include_amazon_reg_ids, include_chrome_reg_ids, include_chrome_web_reg_ids, include_android_reg_ids, include_aliases, target_channel, id, value, name, aggregation, is_ios, is_android, is_huawei, is_any_web, is_chrome_web, is_firefox, is_safari, is_wp_wns, is_adm, is_chrome, app_id, external_id, idempotency_key, contents, headings, subtitle, data, huawei_msg_type, url, web_url, app_url, ios_attachments, template_id, content_available, mutable_content, target_content_identifier, big_picture, huawei_big_picture, adm_big_picture, chrome_big_picture, chrome_web_image, buttons, web_buttons, ios_category, android_channel_id, huawei_channel_id, existing_android_channel_id, huawei_existing_channel_id, android_background_layout, small_icon, huawei_small_icon, large_icon, huawei_large_icon, adm_small_icon, adm_large_icon, chrome_web_icon, chrome_web_badge, firefox_icon, chrome_icon, ios_sound, android_sound, huawei_sound, adm_sound, wp_wns_sound, android_led_color, huawei_led_color, android_accent_color, huawei_accent_color, android_visibility, huawei_visibility, ios_badge_type, ios_badge_count, collapse_id, web_push_topic, apns_alert, delayed_option, delivery_time_of_day, ttl, priority, apns_push_type_override, throttle_rate_per_minute, android_group, android_group_message, adm_group, adm_group_message, thread_id, summary_arg, summary_arg_count, ios_relevance_score, ios_interruption_level, email_subject, email_body, email_from_name, email_from_address, email_reply_to_address, email_preheader, disable_email_click_tracking, include_unsubscribed, email_bcc, email_sender_domain, sms_from, sms_media_urls, filters, custom_data, huawei_badge_class, huawei_badge_add_num, huawei_badge_set_num, huawei_category, huawei_bi_tag, successful, failed, errored, converted, received, outcomes, remaining, queued_at, send_after, completed_at, platform_delivery_stats, canceled, bcc_sent].hash
+      [included_segments, excluded_segments, include_subscription_ids, include_email_tokens, email_to, include_phone_numbers, include_ios_tokens, include_wp_wns_uris, include_amazon_reg_ids, include_chrome_reg_ids, include_chrome_web_reg_ids, include_android_reg_ids, include_aliases, target_channel, id, value, name, aggregation, is_ios, is_android, is_huawei, is_any_web, is_chrome_web, is_firefox, is_safari, is_wp_wns, is_adm, is_chrome, app_id, external_id, idempotency_key, contents, headings, subtitle, data, huawei_msg_type, url, web_url, app_url, ios_attachments, template_id, content_available, mutable_content, target_content_identifier, big_picture, global_image, huawei_big_picture, adm_big_picture, chrome_big_picture, chrome_web_image, buttons, web_buttons, ios_category, android_channel_id, huawei_channel_id, existing_android_channel_id, huawei_existing_channel_id, android_background_layout, small_icon, huawei_small_icon, large_icon, huawei_large_icon, adm_small_icon, adm_large_icon, chrome_web_icon, chrome_web_badge, firefox_icon, chrome_icon, ios_sound, android_sound, huawei_sound, adm_sound, wp_wns_sound, android_led_color, huawei_led_color, android_accent_color, huawei_accent_color, android_visibility, huawei_visibility, ios_badge_type, ios_badge_count, collapse_id, web_push_topic, apns_alert, delayed_option, delivery_time_of_day, ttl, priority, apns_push_type_override, throttle_rate_per_minute, android_group, android_group_message, adm_group, adm_group_message, thread_id, summary_arg, summary_arg_count, ios_relevance_score, ios_interruption_level, email_subject, email_body, email_from_name, email_from_address, email_reply_to_address, email_preheader, disable_email_click_tracking, include_unsubscribed, email_bcc, email_sender_domain, sms_from, sms_media_urls, filters, custom_data, huawei_badge_class, huawei_badge_add_num, huawei_badge_set_num, huawei_category, huawei_bi_tag, successful, failed, errored, converted, received, outcomes, remaining, queued_at, send_after, completed_at, platform_delivery_stats, canceled, bcc_sent].hash
     end
 
     # Builds the object from hash

--- a/spec/models/basic_notification_all_of_spec.rb
+++ b/spec/models/basic_notification_all_of_spec.rb
@@ -215,6 +215,12 @@ describe OneSignal::BasicNotificationAllOf do
     end
   end
 
+  describe 'test attribute "global_image"' do
+    it 'should work' do
+      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
+    end
+  end
+
   describe 'test attribute "huawei_big_picture"' do
     it 'should work' do
       # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers

--- a/spec/models/basic_notification_spec.rb
+++ b/spec/models/basic_notification_spec.rb
@@ -303,6 +303,12 @@ describe OneSignal::BasicNotification do
     end
   end
 
+  describe 'test attribute "global_image"' do
+    it 'should work' do
+      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
+    end
+  end
+
   describe 'test attribute "huawei_big_picture"' do
     it 'should work' do
       # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -303,6 +303,12 @@ describe OneSignal::Notification do
     end
   end
 
+  describe 'test attribute "global_image"' do
+    it 'should work' do
+      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
+    end
+  end
+
   describe 'test attribute "huawei_big_picture"' do
     it 'should work' do
       # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers

--- a/spec/models/notification_with_meta_spec.rb
+++ b/spec/models/notification_with_meta_spec.rb
@@ -303,6 +303,12 @@ describe OneSignal::NotificationWithMeta do
     end
   end
 
+  describe 'test attribute "global_image"' do
+    it 'should work' do
+      # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers
+    end
+  end
+
   describe 'test attribute "huawei_big_picture"' do
     it 'should work' do
       # assertion here. ref: https://www.relishapp.com/rspec/rspec-expectations/docs/built-in-matchers


### PR DESCRIPTION
## Release v5.11.0

### 🚀 Features
- feat: [SDK-4955] add global_image to notification model

### 🐛 Bug Fixes
- fix: [SDK-3548] remove embedded app_id query string from export_events path

---
_Generated from [OneSignal/api-client-libraries@ddf7097...896df91](https://github.com/OneSignal/api-client-libraries/compare/ddf70978c387722498536f11b17850c47857c230...896df9152f41b31f8b0cd123ebcf551d4e7ab2cb)._